### PR TITLE
updated schemas to use both data_key and attributes for serialization

### DIFF
--- a/src/commercetools/schemas/_api_client.py
+++ b/src/commercetools/schemas/_api_client.py
@@ -16,7 +16,7 @@ class ApiClientDraftSchema(marshmallow.Schema):
     name = marshmallow.fields.String(allow_none=True)
     scope = marshmallow.fields.String(allow_none=True)
     delete_days_after_creation = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterCreation"
+        allow_none=True, missing=None, data_key="deleteDaysAfterCreation", attribute="deleteDaysAfterCreation"
     )
 
     class Meta:
@@ -53,13 +53,13 @@ class ApiClientSchema(marshmallow.Schema):
     name = marshmallow.fields.String(allow_none=True)
     scope = marshmallow.fields.String(allow_none=True)
     created_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="createdAt"
+        allow_none=True, missing=None, data_key="createdAt", attribute="createdAt"
     )
     last_used_at = marshmallow.fields.Date(
-        allow_none=True, missing=None, data_key="lastUsedAt"
+        allow_none=True, missing=None, data_key="lastUsedAt", attribute="lastUsedAt"
     )
     delete_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="deleteAt"
+        allow_none=True, missing=None, data_key="deleteAt", attribute="deleteAt"
     )
     secret = marshmallow.fields.String(allow_none=True, missing=None)
 

--- a/src/commercetools/schemas/_cart.py
+++ b/src/commercetools/schemas/_cart.py
@@ -102,10 +102,10 @@ class CartDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CartDraft`."
     currency = marshmallow.fields.String()
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
     customer_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerEmail"
+        allow_none=True, missing=None, data_key="customerEmail", attribute="customerEmail"
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupResourceIdentifierSchema",
@@ -113,9 +113,10 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     store = marshmallow.fields.Nested(
         nested="commercetools.schemas._store.StoreResourceIdentifierSchema",
@@ -125,19 +126,20 @@ class CartDraftSchema(marshmallow.Schema):
     )
     country = marshmallow.fields.String(allow_none=True, missing=None)
     inventory_mode = marshmallow_enum.EnumField(
-        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode"
+        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode", attribute="inventoryMode"
     )
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, missing=None, data_key="taxMode"
+        types.TaxMode, by_value=True, missing=None, data_key="taxMode", attribute="taxMode"
     )
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
     tax_calculation_mode = marshmallow_enum.EnumField(
         types.TaxCalculationMode,
         by_value=True,
         missing=None,
         data_key="taxCalculationMode",
+        attribute="taxCalculationMode",
     )
     line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.LineItemDraftSchema",
@@ -146,6 +148,7 @@ class CartDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="lineItems",
+        attribute="lineItems",
     )
     custom_line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.CustomLineItemDraftSchema",
@@ -154,6 +157,7 @@ class CartDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="customLineItems",
+        attribute="customLineItems",
     )
     shipping_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -161,6 +165,7 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingAddress",
+        attribute="shippingAddress",
     )
     billing_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -168,6 +173,7 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="billingAddress",
+        attribute="billingAddress",
     )
     shipping_method = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingMethodResourceIdentifierSchema",
@@ -175,6 +181,7 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     external_tax_rate_for_shipping_method = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -182,6 +189,7 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRateForShippingMethod",
+        attribute="externalTaxRateForShippingMethod",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -191,7 +199,7 @@ class CartDraftSchema(marshmallow.Schema):
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
     origin = marshmallow_enum.EnumField(types.CartOrigin, by_value=True, missing=None)
     shipping_rate_input = helpers.Discriminator(
@@ -204,6 +212,7 @@ class CartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
     item_shipping_addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -212,6 +221,7 @@ class CartDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="itemShippingAddresses",
+        attribute="itemShippingAddresses",
     )
 
     class Meta:
@@ -275,13 +285,13 @@ class CartResourceIdentifierSchema(ResourceIdentifierSchema):
 class CartSchema(LoggedResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.Cart`."
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
     customer_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerEmail"
+        allow_none=True, missing=None, data_key="customerEmail", attribute="customerEmail"
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     store = marshmallow.fields.Nested(
         nested="commercetools.schemas._store.StoreKeyReferenceSchema",
@@ -295,6 +305,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="lineItems",
+        attribute="lineItems",
     )
     custom_line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.CustomLineItemSchema",
@@ -302,6 +313,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="customLineItems",
+        attribute="customLineItems",
     )
     total_price = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -312,6 +324,7 @@ class CartSchema(LoggedResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedPriceSchema",
@@ -319,9 +332,10 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     cart_state = marshmallow_enum.EnumField(
-        types.CartState, by_value=True, data_key="cartState"
+        types.CartState, by_value=True, data_key="cartState", attribute="cartState"
     )
     shipping_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -329,6 +343,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingAddress",
+        attribute="shippingAddress",
     )
     billing_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -336,18 +351,19 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="billingAddress",
+        attribute="billingAddress",
     )
     inventory_mode = marshmallow_enum.EnumField(
-        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode"
+        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode", attribute="inventoryMode"
     )
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, data_key="taxMode"
+        types.TaxMode, by_value=True, data_key="taxMode", attribute="taxMode"
     )
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
     tax_calculation_mode = marshmallow_enum.EnumField(
-        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode"
+        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode", attribute="taxCalculationMode"
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupReferenceSchema",
@@ -355,6 +371,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     country = marshmallow.fields.String(missing=None)
     shipping_info = marshmallow.fields.Nested(
@@ -363,6 +380,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingInfo",
+        attribute="shippingInfo",
     )
     discount_codes = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountCodeInfoSchema",
@@ -371,6 +389,7 @@ class CartSchema(LoggedResourceSchema):
         many=True,
         missing=None,
         data_key="discountCodes",
+        attribute="discountCodes",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -384,10 +403,11 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="paymentInfo",
+        attribute="paymentInfo",
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
     refused_gifts = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart_discount.CartDiscountReferenceSchema",
@@ -395,6 +415,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="refusedGifts",
+        attribute="refusedGifts",
     )
     origin = marshmallow_enum.EnumField(types.CartOrigin, by_value=True)
     shipping_rate_input = helpers.Discriminator(
@@ -407,6 +428,7 @@ class CartSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
     item_shipping_addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -415,6 +437,7 @@ class CartSchema(LoggedResourceSchema):
         many=True,
         missing=None,
         data_key="itemShippingAddresses",
+        attribute="itemShippingAddresses",
     )
 
     class Meta:
@@ -526,6 +549,7 @@ class CustomLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -533,6 +557,7 @@ class CustomLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -546,6 +571,7 @@ class CustomLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -575,6 +601,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     total_price = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -585,6 +612,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     slug = marshmallow.fields.String(allow_none=True)
     quantity = marshmallow.fields.Integer(allow_none=True)
@@ -600,6 +628,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxRateSchema",
@@ -607,6 +636,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxRate",
+        attribute="taxRate",
     )
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
@@ -614,6 +644,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -627,6 +658,7 @@ class CustomLineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -644,6 +676,7 @@ class DiscountCodeInfoSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
     state = marshmallow_enum.EnumField(types.DiscountCodeState, by_value=True)
 
@@ -667,6 +700,7 @@ class DiscountedLineItemPortionSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountedAmount",
+        attribute="discountedAmount",
     )
 
     class Meta:
@@ -685,6 +719,7 @@ class DiscountedLineItemPriceForQuantitySchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountedPrice",
+        attribute="discountedPrice",
     )
 
     class Meta:
@@ -712,6 +747,7 @@ class DiscountedLineItemPriceSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="includedDiscounts",
+        attribute="includedDiscounts",
     )
 
     class Meta:
@@ -734,6 +770,7 @@ class ExternalLineItemTotalPriceSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
 
     class Meta:
@@ -751,12 +788,14 @@ class ExternalTaxAmountDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalGross",
+        attribute="totalGross",
     )
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxRate",
+        attribute="taxRate",
     )
 
     class Meta:
@@ -780,9 +819,10 @@ class ExternalTaxRateDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="subRates",
+        attribute="subRates",
     )
     included_in_price = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="includedInPrice"
+        allow_none=True, missing=None, data_key="includedInPrice", attribute="includedInPrice"
     )
 
     class Meta:
@@ -830,7 +870,7 @@ class ItemShippingDetailsSchema(marshmallow.Schema):
 
 class ItemShippingTargetSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ItemShippingTarget`."
-    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey")
+    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey", attribute="addressKey")
     quantity = marshmallow.fields.Integer(allow_none=True)
 
     class Meta:
@@ -844,10 +884,10 @@ class ItemShippingTargetSchema(marshmallow.Schema):
 class LineItemDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.LineItemDraft`."
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
@@ -857,6 +897,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -864,6 +905,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -871,6 +913,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -884,6 +927,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -891,6 +935,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -898,6 +943,7 @@ class LineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -911,16 +957,17 @@ class LineItemDraftSchema(marshmallow.Schema):
 class LineItemSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.LineItem`."
     id = marshmallow.fields.String(allow_none=True)
-    product_id = marshmallow.fields.String(allow_none=True, data_key="productId")
+    product_id = marshmallow.fields.String(allow_none=True, data_key="productId", attribute="productId")
     name = LocalizedStringField(allow_none=True)
     product_slug = LocalizedStringField(
-        allow_none=True, missing=None, data_key="productSlug"
+        allow_none=True, missing=None, data_key="productSlug", attribute="productSlug"
     )
     product_type = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.ProductTypeReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productType",
+        attribute="productType",
     )
     variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
@@ -938,12 +985,14 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     state = marshmallow.fields.Nested(
@@ -958,6 +1007,7 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxRate",
+        attribute="taxRate",
     )
     supply_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -965,6 +1015,7 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -972,6 +1023,7 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
@@ -979,12 +1031,13 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     price_mode = marshmallow_enum.EnumField(
-        types.LineItemPriceMode, by_value=True, data_key="priceMode"
+        types.LineItemPriceMode, by_value=True, data_key="priceMode", attribute="priceMode"
     )
     line_item_mode = marshmallow_enum.EnumField(
-        types.LineItemMode, by_value=True, data_key="lineItemMode"
+        types.LineItemMode, by_value=True, data_key="lineItemMode", attribute="lineItemMode"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -998,6 +1051,7 @@ class LineItemSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1027,7 +1081,7 @@ class ReplicaCartDraftSchema(marshmallow.Schema):
 class ShippingInfoSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ShippingInfo`."
     shipping_method_name = marshmallow.fields.String(
-        allow_none=True, data_key="shippingMethodName"
+        allow_none=True, data_key="shippingMethodName", attribute="shippingMethodName"
     )
     price = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -1043,6 +1097,7 @@ class ShippingInfoSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedItemPriceSchema",
@@ -1050,6 +1105,7 @@ class ShippingInfoSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxRateSchema",
@@ -1057,6 +1113,7 @@ class ShippingInfoSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxRate",
+        attribute="taxRate",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryReferenceSchema",
@@ -1064,6 +1121,7 @@ class ShippingInfoSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     shipping_method = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingMethodReferenceSchema",
@@ -1071,6 +1129,7 @@ class ShippingInfoSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     deliveries = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliverySchema",
@@ -1085,9 +1144,10 @@ class ShippingInfoSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="discountedPrice",
+        attribute="discountedPrice",
     )
     shipping_method_state = marshmallow_enum.EnumField(
-        types.ShippingMethodState, by_value=True, data_key="shippingMethodState"
+        types.ShippingMethodState, by_value=True, data_key="shippingMethodState", attribute="shippingMethodState"
     )
 
     class Meta:
@@ -1153,6 +1213,7 @@ class TaxedItemPriceSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalNet",
+        attribute="totalNet",
     )
     total_gross = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -1163,6 +1224,7 @@ class TaxedItemPriceSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalGross",
+        attribute="totalGross",
     )
 
     class Meta:
@@ -1180,12 +1242,14 @@ class TaxedPriceSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalNet",
+        attribute="totalNet",
     )
     total_gross = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalGross",
+        attribute="totalGross",
     )
     tax_portions = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxPortionSchema",
@@ -1193,6 +1257,7 @@ class TaxedPriceSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="taxPortions",
+        attribute="taxPortions",
     )
 
     class Meta:
@@ -1219,6 +1284,7 @@ class CartAddCustomLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -1232,6 +1298,7 @@ class CartAddCustomLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1287,19 +1354,20 @@ class CartAddLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
-        data_key="externalTaxRate",
+        data_key="externalTaxRate", attribute="externalTaxRate",
     )
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
@@ -1309,6 +1377,7 @@ class CartAddLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -1316,6 +1385,7 @@ class CartAddLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -1323,6 +1393,7 @@ class CartAddLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1330,6 +1401,7 @@ class CartAddLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1365,6 +1437,7 @@ class CartAddShoppingListActionSchema(CartUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shoppingList",
+        attribute="shoppingList",
     )
     supply_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -1372,6 +1445,7 @@ class CartAddShoppingListActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -1379,6 +1453,7 @@ class CartAddShoppingListActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
 
     class Meta:
@@ -1395,7 +1470,7 @@ class CartApplyDeltaToCustomLineItemShippingDetailsTargetsActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.CartApplyDeltaToCustomLineItemShippingDetailsTargetsAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     targets_delta = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingTargetSchema",
@@ -1403,6 +1478,7 @@ class CartApplyDeltaToCustomLineItemShippingDetailsTargetsActionSchema(
         allow_none=True,
         many=True,
         data_key="targetsDelta",
+        attribute="targetsDelta",
     )
 
     class Meta:
@@ -1418,13 +1494,14 @@ class CartApplyDeltaToLineItemShippingDetailsTargetsActionSchema(
     CartUpdateActionSchema
 ):
     "Marshmallow schema for :class:`commercetools.types.CartApplyDeltaToLineItemShippingDetailsTargetsAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     targets_delta = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingTargetSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         many=True,
         data_key="targetsDelta",
+        attribute="targetsDelta",
     )
 
     class Meta:
@@ -1439,7 +1516,7 @@ class CartApplyDeltaToLineItemShippingDetailsTargetsActionSchema(
 class CartChangeCustomLineItemMoneyActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeCustomLineItemMoneyAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     money = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -1459,7 +1536,7 @@ class CartChangeCustomLineItemMoneyActionSchema(CartUpdateActionSchema):
 class CartChangeCustomLineItemQuantityActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeCustomLineItemQuantityAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
 
@@ -1474,7 +1551,7 @@ class CartChangeCustomLineItemQuantityActionSchema(CartUpdateActionSchema):
 
 class CartChangeLineItemQuantityActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeLineItemQuantityAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True)
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -1482,6 +1559,7 @@ class CartChangeLineItemQuantityActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -1489,6 +1567,7 @@ class CartChangeLineItemQuantityActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
 
     class Meta:
@@ -1503,7 +1582,7 @@ class CartChangeLineItemQuantityActionSchema(CartUpdateActionSchema):
 class CartChangeTaxCalculationModeActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeTaxCalculationModeAction`."
     tax_calculation_mode = marshmallow_enum.EnumField(
-        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode"
+        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode", attribute="taxCalculationMode"
     )
 
     class Meta:
@@ -1518,7 +1597,7 @@ class CartChangeTaxCalculationModeActionSchema(CartUpdateActionSchema):
 class CartChangeTaxModeActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeTaxModeAction`."
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, data_key="taxMode"
+        types.TaxMode, by_value=True, data_key="taxMode", attribute="taxMode"
     )
 
     class Meta:
@@ -1533,7 +1612,7 @@ class CartChangeTaxModeActionSchema(CartUpdateActionSchema):
 class CartChangeTaxRoundingModeActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartChangeTaxRoundingModeAction`."
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
 
     class Meta:
@@ -1548,7 +1627,7 @@ class CartChangeTaxRoundingModeActionSchema(CartUpdateActionSchema):
 class CartRecalculateActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartRecalculateAction`."
     update_product_data = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="updateProductData"
+        allow_none=True, missing=None, data_key="updateProductData", attribute="updateProductData"
     )
 
     class Meta:
@@ -1563,7 +1642,7 @@ class CartRecalculateActionSchema(CartUpdateActionSchema):
 class CartRemoveCustomLineItemActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartRemoveCustomLineItemAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
 
     class Meta:
@@ -1581,7 +1660,7 @@ class CartRemoveDiscountCodeActionSchema(CartUpdateActionSchema):
         nested="commercetools.schemas._discount_code.DiscountCodeReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
-        data_key="discountCode",
+        data_key="discountCode", attribute="discountCode",
     )
 
     class Meta:
@@ -1595,7 +1674,7 @@ class CartRemoveDiscountCodeActionSchema(CartUpdateActionSchema):
 
 class CartRemoveItemShippingAddressActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartRemoveItemShippingAddressAction`."
-    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey")
+    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey", attribute="addressKey")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1608,7 +1687,7 @@ class CartRemoveItemShippingAddressActionSchema(CartUpdateActionSchema):
 
 class CartRemoveLineItemActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartRemoveLineItemAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -1616,6 +1695,7 @@ class CartRemoveLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -1623,6 +1703,7 @@ class CartRemoveLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
     shipping_details_to_remove = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1630,6 +1711,7 @@ class CartRemoveLineItemActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingDetailsToRemove",
+        attribute="shippingDetailsToRemove",
     )
 
     class Meta:
@@ -1661,7 +1743,7 @@ class CartRemovePaymentActionSchema(CartUpdateActionSchema):
 class CartSetAnonymousIdActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetAnonymousIdAction`."
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -1698,6 +1780,7 @@ class CartSetCartTotalTaxActionSchema(CartUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="externalTotalGross",
+        attribute="externalTotalGross",
     )
     external_tax_portions = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxPortionSchema",
@@ -1706,6 +1789,7 @@ class CartSetCartTotalTaxActionSchema(CartUpdateActionSchema):
         many=True,
         missing=None,
         data_key="externalTaxPortions",
+        attribute="externalTaxPortions",
     )
 
     class Meta:
@@ -1747,7 +1831,7 @@ class CartSetCustomFieldActionSchema(CartUpdateActionSchema):
 class CartSetCustomLineItemCustomFieldActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomLineItemCustomFieldAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -1764,7 +1848,7 @@ class CartSetCustomLineItemCustomFieldActionSchema(CartUpdateActionSchema):
 class CartSetCustomLineItemCustomTypeActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomLineItemCustomTypeAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -1786,7 +1870,7 @@ class CartSetCustomLineItemCustomTypeActionSchema(CartUpdateActionSchema):
 class CartSetCustomLineItemShippingDetailsActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomLineItemShippingDetailsAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1794,6 +1878,7 @@ class CartSetCustomLineItemShippingDetailsActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1808,7 +1893,7 @@ class CartSetCustomLineItemShippingDetailsActionSchema(CartUpdateActionSchema):
 class CartSetCustomLineItemTaxAmountActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomLineItemTaxAmountAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     external_tax_amount = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxAmountDraftSchema",
@@ -1816,6 +1901,7 @@ class CartSetCustomLineItemTaxAmountActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -1830,7 +1916,7 @@ class CartSetCustomLineItemTaxAmountActionSchema(CartUpdateActionSchema):
 class CartSetCustomLineItemTaxRateActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomLineItemTaxRateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1838,6 +1924,7 @@ class CartSetCustomLineItemTaxRateActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1852,13 +1939,14 @@ class CartSetCustomLineItemTaxRateActionSchema(CartUpdateActionSchema):
 class CartSetCustomShippingMethodActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomShippingMethodAction`."
     shipping_method_name = marshmallow.fields.String(
-        allow_none=True, data_key="shippingMethodName"
+        allow_none=True, data_key="shippingMethodName", attribute="shippingMethodName"
     )
     shipping_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryResourceIdentifierSchema",
@@ -1866,6 +1954,7 @@ class CartSetCustomShippingMethodActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1873,6 +1962,7 @@ class CartSetCustomShippingMethodActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1924,6 +2014,7 @@ class CartSetCustomerGroupActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
 
     class Meta:
@@ -1938,7 +2029,7 @@ class CartSetCustomerGroupActionSchema(CartUpdateActionSchema):
 class CartSetCustomerIdActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetCustomerIdAction`."
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
 
     class Meta:
@@ -1953,7 +2044,7 @@ class CartSetCustomerIdActionSchema(CartUpdateActionSchema):
 class CartSetDeleteDaysAfterLastModificationActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetDeleteDaysAfterLastModificationAction`."
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
 
     class Meta:
@@ -1967,7 +2058,7 @@ class CartSetDeleteDaysAfterLastModificationActionSchema(CartUpdateActionSchema)
 
 class CartSetLineItemCustomFieldActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemCustomFieldAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
 
@@ -1982,7 +2073,7 @@ class CartSetLineItemCustomFieldActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemCustomTypeActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemCustomTypeAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2002,13 +2093,14 @@ class CartSetLineItemCustomTypeActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemPriceActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemPriceAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
 
     class Meta:
@@ -2022,13 +2114,14 @@ class CartSetLineItemPriceActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemShippingDetailsActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemShippingDetailsAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -2042,13 +2135,14 @@ class CartSetLineItemShippingDetailsActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemTaxAmountActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemTaxAmountAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_tax_amount = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxAmountDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -2062,13 +2156,14 @@ class CartSetLineItemTaxAmountActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemTaxRateActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemTaxRateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -2082,13 +2177,14 @@ class CartSetLineItemTaxRateActionSchema(CartUpdateActionSchema):
 
 class CartSetLineItemTotalPriceActionSchema(CartUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartSetLineItemTotalPriceAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
 
     class Meta:
@@ -2139,6 +2235,7 @@ class CartSetShippingMethodActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -2146,6 +2243,7 @@ class CartSetShippingMethodActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -2165,6 +2263,7 @@ class CartSetShippingMethodTaxAmountActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -2184,6 +2283,7 @@ class CartSetShippingMethodTaxRateActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -2207,6 +2307,7 @@ class CartSetShippingRateInputActionSchema(CartUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_cart_discount.py
+++ b/src/commercetools/schemas/_cart_discount.py
@@ -63,7 +63,7 @@ class CartDiscountDraftSchema(marshmallow.Schema):
         allow_none=True,
     )
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, data_key="cartPredicate"
+        allow_none=True, data_key="cartPredicate", attribute="cartPredicate"
     )
     target = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -78,21 +78,21 @@ class CartDiscountDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
     )
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
     is_active = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isActive"
+        allow_none=True, missing=None, data_key="isActive", attribute="isActive"
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     requires_discount_code = marshmallow.fields.Bool(
-        allow_none=True, data_key="requiresDiscountCode"
+        allow_none=True, data_key="requiresDiscountCode", attribute="requiresDiscountCode"
     )
     stacking_mode = marshmallow_enum.EnumField(
-        types.StackingMode, by_value=True, missing=None, data_key="stackingMode"
+        types.StackingMode, by_value=True, missing=None, data_key="stackingMode", attribute="stackingMode"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -175,7 +175,7 @@ class CartDiscountSchema(LoggedResourceSchema):
         allow_none=True,
     )
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, data_key="cartPredicate"
+        allow_none=True, data_key="cartPredicate", attribute="cartPredicate"
     )
     target = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -190,16 +190,16 @@ class CartDiscountSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
     )
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     requires_discount_code = marshmallow.fields.Bool(
-        allow_none=True, data_key="requiresDiscountCode"
+        allow_none=True, data_key="requiresDiscountCode", attribute="requiresDiscountCode"
     )
     references = marshmallow.fields.List(
         helpers.Discriminator(
@@ -234,7 +234,7 @@ class CartDiscountSchema(LoggedResourceSchema):
         )
     )
     stacking_mode = marshmallow_enum.EnumField(
-        types.StackingMode, by_value=True, data_key="stackingMode"
+        types.StackingMode, by_value=True, data_key="stackingMode", attribute="stackingMode"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -330,7 +330,7 @@ class CartDiscountValueSchema(marshmallow.Schema):
 class CartDiscountChangeCartPredicateActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountChangeCartPredicateAction`."
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, data_key="cartPredicate"
+        allow_none=True, data_key="cartPredicate", attribute="cartPredicate"
     )
 
     class Meta:
@@ -344,7 +344,7 @@ class CartDiscountChangeCartPredicateActionSchema(CartDiscountUpdateActionSchema
 
 class CartDiscountChangeIsActiveActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountChangeIsActiveAction`."
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -373,7 +373,7 @@ class CartDiscountChangeRequiresDiscountCodeActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountChangeRequiresDiscountCodeAction`."
     requires_discount_code = marshmallow.fields.Bool(
-        allow_none=True, data_key="requiresDiscountCode"
+        allow_none=True, data_key="requiresDiscountCode", attribute="requiresDiscountCode"
     )
 
     class Meta:
@@ -387,7 +387,7 @@ class CartDiscountChangeRequiresDiscountCodeActionSchema(
 
 class CartDiscountChangeSortOrderActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountChangeSortOrderAction`."
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -401,7 +401,7 @@ class CartDiscountChangeSortOrderActionSchema(CartDiscountUpdateActionSchema):
 class CartDiscountChangeStackingModeActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountChangeStackingModeAction`."
     stacking_mode = marshmallow_enum.EnumField(
-        types.StackingMode, by_value=True, data_key="stackingMode"
+        types.StackingMode, by_value=True, data_key="stackingMode", attribute="stackingMode"
     )
 
     class Meta:
@@ -547,7 +547,7 @@ class CartDiscountSetKeyActionSchema(CartDiscountUpdateActionSchema):
 class CartDiscountSetValidFromActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountSetValidFromAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
 
     class Meta:
@@ -562,10 +562,10 @@ class CartDiscountSetValidFromActionSchema(CartDiscountUpdateActionSchema):
 class CartDiscountSetValidFromAndUntilActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountSetValidFromAndUntilAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -580,7 +580,7 @@ class CartDiscountSetValidFromAndUntilActionSchema(CartDiscountUpdateActionSchem
 class CartDiscountSetValidUntilActionSchema(CartDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CartDiscountSetValidUntilAction`."
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -629,13 +629,14 @@ class CartDiscountValueGiftLineItemSchema(CartDiscountValueSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
     )
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     supply_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -643,6 +644,7 @@ class CartDiscountValueGiftLineItemSchema(CartDiscountValueSchema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
 
     class Meta:
@@ -671,16 +673,16 @@ class MultiBuyCustomLineItemsTargetSchema(CartDiscountTargetSchema):
     "Marshmallow schema for :class:`commercetools.types.MultiBuyCustomLineItemsTarget`."
     predicate = marshmallow.fields.String(allow_none=True)
     trigger_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="triggerQuantity"
+        allow_none=True, data_key="triggerQuantity", attribute="triggerQuantity"
     )
     discounted_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="discountedQuantity"
+        allow_none=True, data_key="discountedQuantity", attribute="discountedQuantity"
     )
     max_occurrence = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxOccurrence"
+        allow_none=True, missing=None, data_key="maxOccurrence", attribute="maxOccurrence"
     )
     selection_mode = marshmallow_enum.EnumField(
-        types.SelectionMode, by_value=True, data_key="selectionMode"
+        types.SelectionMode, by_value=True, data_key="selectionMode", attribute="selectionMode"
     )
 
     class Meta:
@@ -696,16 +698,16 @@ class MultiBuyLineItemsTargetSchema(CartDiscountTargetSchema):
     "Marshmallow schema for :class:`commercetools.types.MultiBuyLineItemsTarget`."
     predicate = marshmallow.fields.String(allow_none=True)
     trigger_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="triggerQuantity"
+        allow_none=True, data_key="triggerQuantity", attribute="triggerQuantity"
     )
     discounted_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="discountedQuantity"
+        allow_none=True, data_key="discountedQuantity", attribute="discountedQuantity"
     )
     max_occurrence = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxOccurrence"
+        allow_none=True, missing=None, data_key="maxOccurrence", attribute="maxOccurrence"
     )
     selection_mode = marshmallow_enum.EnumField(
-        types.SelectionMode, by_value=True, data_key="selectionMode"
+        types.SelectionMode, by_value=True, data_key="selectionMode", attribute="selectionMode"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_category.py
+++ b/src/commercetools/schemas/_category.py
@@ -56,19 +56,19 @@ class CategoryDraftSchema(marshmallow.Schema):
         missing=None,
     )
     order_hint = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderHint"
+        allow_none=True, missing=None, data_key="orderHint", attribute="orderHint"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -160,18 +160,18 @@ class CategorySchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
     )
-    order_hint = marshmallow.fields.String(allow_none=True, data_key="orderHint")
+    order_hint = marshmallow.fields.String(allow_none=True, data_key="orderHint", attribute="orderHint")
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -274,10 +274,10 @@ class CategoryAddAssetActionSchema(CategoryUpdateActionSchema):
 class CategoryChangeAssetNameActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategoryChangeAssetNameAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     name = LocalizedStringField(allow_none=True)
 
@@ -293,7 +293,7 @@ class CategoryChangeAssetNameActionSchema(CategoryUpdateActionSchema):
 class CategoryChangeAssetOrderActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategoryChangeAssetOrderAction`."
     asset_order = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="assetOrder"
+        marshmallow.fields.String(allow_none=True), data_key="assetOrder", attribute="assetOrder"
     )
 
     class Meta:
@@ -320,7 +320,7 @@ class CategoryChangeNameActionSchema(CategoryUpdateActionSchema):
 
 class CategoryChangeOrderHintActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategoryChangeOrderHintAction`."
-    order_hint = marshmallow.fields.String(allow_none=True, data_key="orderHint")
+    order_hint = marshmallow.fields.String(allow_none=True, data_key="orderHint", attribute="orderHint")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -364,10 +364,10 @@ class CategoryChangeSlugActionSchema(CategoryUpdateActionSchema):
 class CategoryRemoveAssetActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategoryRemoveAssetAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
 
     class Meta:
@@ -382,10 +382,10 @@ class CategoryRemoveAssetActionSchema(CategoryUpdateActionSchema):
 class CategorySetAssetCustomFieldActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetCustomFieldAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -402,10 +402,10 @@ class CategorySetAssetCustomFieldActionSchema(CategoryUpdateActionSchema):
 class CategorySetAssetCustomTypeActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetCustomTypeAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -427,10 +427,10 @@ class CategorySetAssetCustomTypeActionSchema(CategoryUpdateActionSchema):
 class CategorySetAssetDescriptionActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetDescriptionAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
 
@@ -445,9 +445,9 @@ class CategorySetAssetDescriptionActionSchema(CategoryUpdateActionSchema):
 
 class CategorySetAssetKeyActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetKeyAction`."
-    asset_id = marshmallow.fields.String(allow_none=True, data_key="assetId")
+    asset_id = marshmallow.fields.String(allow_none=True, data_key="assetId", attribute="assetId")
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
 
     class Meta:
@@ -462,10 +462,10 @@ class CategorySetAssetKeyActionSchema(CategoryUpdateActionSchema):
 class CategorySetAssetSourcesActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetSourcesAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     sources = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AssetSourceSchema",
@@ -486,10 +486,10 @@ class CategorySetAssetSourcesActionSchema(CategoryUpdateActionSchema):
 class CategorySetAssetTagsActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetAssetTagsAction`."
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     tags = marshmallow.fields.List(
         marshmallow.fields.String(allow_none=True), missing=None
@@ -553,7 +553,7 @@ class CategorySetDescriptionActionSchema(CategoryUpdateActionSchema):
 class CategorySetExternalIdActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetExternalIdAction`."
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
 
     class Meta:
@@ -581,7 +581,7 @@ class CategorySetKeyActionSchema(CategoryUpdateActionSchema):
 class CategorySetMetaDescriptionActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetMetaDescriptionAction`."
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
 
     class Meta:
@@ -596,7 +596,7 @@ class CategorySetMetaDescriptionActionSchema(CategoryUpdateActionSchema):
 class CategorySetMetaKeywordsActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetMetaKeywordsAction`."
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
 
     class Meta:
@@ -611,7 +611,7 @@ class CategorySetMetaKeywordsActionSchema(CategoryUpdateActionSchema):
 class CategorySetMetaTitleActionSchema(CategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CategorySetMetaTitleAction`."
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_channel.py
+++ b/src/commercetools/schemas/_channel.py
@@ -59,6 +59,7 @@ class ChannelDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="geoLocation",
+        attribute="geoLocation",
     )
 
     class Meta:
@@ -139,6 +140,7 @@ class ChannelSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="reviewRatingStatistics",
+        attribute="reviewRatingStatistics",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -152,6 +154,7 @@ class ChannelSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="geoLocation",
+        attribute="geoLocation",
     )
 
     class Meta:
@@ -335,6 +338,7 @@ class ChannelSetGeoLocationActionSchema(ChannelUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="geoLocation",
+        attribute="geoLocation",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_common.py
+++ b/src/commercetools/schemas/_common.py
@@ -51,22 +51,22 @@ class AddressSchema(marshmallow.Schema):
     title = marshmallow.fields.String(allow_none=True, missing=None)
     salutation = marshmallow.fields.String(allow_none=True, missing=None)
     first_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="firstName"
+        allow_none=True, missing=None, data_key="firstName", attribute="firstName"
     )
     last_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lastName"
+        allow_none=True, missing=None, data_key="lastName", attribute="lastName"
     )
     street_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="streetName"
+        allow_none=True, missing=None, data_key="streetName", attribute="streetName"
     )
     street_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="streetNumber"
+        allow_none=True, missing=None, data_key="streetNumber", attribute="streetNumber"
     )
     additional_street_info = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="additionalStreetInfo"
+        allow_none=True, missing=None, data_key="additionalStreetInfo", attribute="additionalStreetInfo"
     )
     postal_code = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="postalCode"
+        allow_none=True, missing=None, data_key="postalCode", attribute="postalCode"
     )
     city = marshmallow.fields.String(allow_none=True, missing=None)
     region = marshmallow.fields.String(allow_none=True, missing=None)
@@ -76,16 +76,16 @@ class AddressSchema(marshmallow.Schema):
     department = marshmallow.fields.String(allow_none=True, missing=None)
     building = marshmallow.fields.String(allow_none=True, missing=None)
     apartment = marshmallow.fields.String(allow_none=True, missing=None)
-    p_o_box = marshmallow.fields.String(allow_none=True, missing=None, data_key="pOBox")
+    p_o_box = marshmallow.fields.String(allow_none=True, missing=None, data_key="pOBox", attribute="pOBox")
     phone = marshmallow.fields.String(allow_none=True, missing=None)
     mobile = marshmallow.fields.String(allow_none=True, missing=None)
     email = marshmallow.fields.String(allow_none=True, missing=None)
     fax = marshmallow.fields.String(allow_none=True, missing=None)
     additional_address_info = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="additionalAddressInfo"
+        allow_none=True, missing=None, data_key="additionalAddressInfo", attribute="additionalAddressInfo"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
 
     class Meta:
@@ -179,7 +179,7 @@ class AssetSourceSchema(marshmallow.Schema):
         missing=None,
     )
     content_type = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="contentType"
+        allow_none=True, missing=None, data_key="contentType", attribute="contentType"
     )
 
     class Meta:
@@ -194,9 +194,9 @@ class BaseResourceSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.BaseResource`."
     id = marshmallow.fields.String(allow_none=True)
     version = marshmallow.fields.Integer(allow_none=True)
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     last_modified_at = marshmallow.fields.DateTime(
-        allow_none=True, data_key="lastModifiedAt"
+        allow_none=True, data_key="lastModifiedAt", attribute="lastModifiedAt"
     )
 
     class Meta:
@@ -210,10 +210,10 @@ class BaseResourceSchema(marshmallow.Schema):
 class ClientLoggingSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ClientLogging`."
     client_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="clientId"
+        allow_none=True, missing=None, data_key="clientId", attribute="clientId"
     )
     external_user_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalUserId"
+        allow_none=True, missing=None, data_key="externalUserId", attribute="externalUserId"
     )
     customer = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer.CustomerReferenceSchema",
@@ -222,7 +222,7 @@ class ClientLoggingSchema(marshmallow.Schema):
         missing=None,
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -301,7 +301,7 @@ class ImageSchema(marshmallow.Schema):
 class KeyReferenceSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.KeyReference`."
     type_id = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, data_key="typeId"
+        types.ReferenceTypeId, by_value=True, data_key="typeId", attribute="typeId"
     )
     key = marshmallow.fields.String(allow_none=True)
 
@@ -316,8 +316,8 @@ class KeyReferenceSchema(marshmallow.Schema):
 
 class MoneySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.Money`."
-    cent_amount = marshmallow.fields.Integer(allow_none=True, data_key="centAmount")
-    currency_code = marshmallow.fields.String(data_key="currencyCode")
+    cent_amount = marshmallow.fields.Integer(allow_none=True, data_key="centAmount", attribute="centAmount")
+    currency_code = marshmallow.fields.String(data_key="currencyCode", attribute="currencyCode")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -368,6 +368,7 @@ class PriceDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -376,10 +377,10 @@ class PriceDraftSchema(marshmallow.Schema):
         missing=None,
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -418,6 +419,7 @@ class PriceSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -426,10 +428,10 @@ class PriceSchema(marshmallow.Schema):
         missing=None,
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
@@ -462,7 +464,7 @@ class PriceSchema(marshmallow.Schema):
 class PriceTierSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PriceTier`."
     minimum_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="minimumQuantity"
+        allow_none=True, data_key="minimumQuantity", attribute="minimumQuantity"
     )
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -481,7 +483,7 @@ class PriceTierSchema(marshmallow.Schema):
 class ReferenceSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.Reference`."
     type_id = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, data_key="typeId"
+        types.ReferenceTypeId, by_value=True, data_key="typeId", attribute="typeId"
     )
     id = marshmallow.fields.String(allow_none=True)
 
@@ -497,7 +499,7 @@ class ReferenceSchema(marshmallow.Schema):
 class ResourceIdentifierSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ResourceIdentifier`."
     type_id = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, missing=None, data_key="typeId"
+        types.ReferenceTypeId, by_value=True, missing=None, data_key="typeId", attribute="typeId"
     )
     id = marshmallow.fields.String(allow_none=True, missing=None)
     key = marshmallow.fields.String(allow_none=True, missing=None)
@@ -532,6 +534,7 @@ class ScopedPriceSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="currentValue",
+        attribute="currentValue",
     )
     country = marshmallow.fields.String(missing=None)
     customer_group = marshmallow.fields.Nested(
@@ -540,6 +543,7 @@ class ScopedPriceSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -548,10 +552,10 @@ class ScopedPriceSchema(marshmallow.Schema):
         missing=None,
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
@@ -656,6 +660,7 @@ class LoggedResourceSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="lastModifiedBy",
+        attribute="lastModifiedBy",
     )
     created_by = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.CreatedBySchema",
@@ -663,6 +668,7 @@ class LoggedResourceSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="createdBy",
+        attribute="createdBy",
     )
 
     class Meta:
@@ -677,7 +683,7 @@ class TypedMoneySchema(MoneySchema):
     "Marshmallow schema for :class:`commercetools.types.TypedMoney`."
     type = marshmallow_enum.EnumField(types.MoneyType, by_value=True)
     fraction_digits = marshmallow.fields.Integer(
-        allow_none=True, data_key="fractionDigits"
+        allow_none=True, data_key="fractionDigits", attribute="fractionDigits"
     )
 
     class Meta:
@@ -704,7 +710,7 @@ class CentPrecisionMoneySchema(TypedMoneySchema):
 class HighPrecisionMoneySchema(TypedMoneySchema):
     "Marshmallow schema for :class:`commercetools.types.HighPrecisionMoney`."
     precise_amount = marshmallow.fields.Integer(
-        allow_none=True, data_key="preciseAmount"
+        allow_none=True, data_key="preciseAmount", attribute="preciseAmount"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_customer.py
+++ b/src/commercetools/schemas/_customer.py
@@ -60,9 +60,9 @@ class CustomerChangePasswordSchema(marshmallow.Schema):
     id = marshmallow.fields.String(allow_none=True)
     version = marshmallow.fields.Integer(allow_none=True)
     current_password = marshmallow.fields.String(
-        allow_none=True, data_key="currentPassword"
+        allow_none=True, data_key="currentPassword", attribute="currentPassword"
     )
-    new_password = marshmallow.fields.String(allow_none=True, data_key="newPassword")
+    new_password = marshmallow.fields.String(allow_none=True, data_key="newPassword", attribute="newPassword")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -76,7 +76,7 @@ class CustomerCreateEmailTokenSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerCreateEmailToken`."
     id = marshmallow.fields.String(allow_none=True)
     version = marshmallow.fields.Integer(allow_none=True, missing=None)
-    ttl_minutes = marshmallow.fields.Integer(allow_none=True, data_key="ttlMinutes")
+    ttl_minutes = marshmallow.fields.Integer(allow_none=True, data_key="ttlMinutes", attribute="ttlMinutes")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -90,7 +90,7 @@ class CustomerCreatePasswordResetTokenSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerCreatePasswordResetToken`."
     email = marshmallow.fields.String(allow_none=True)
     ttl_minutes = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="ttlMinutes"
+        allow_none=True, missing=None, data_key="ttlMinutes", attribute="ttlMinutes"
     )
 
     class Meta:
@@ -104,33 +104,33 @@ class CustomerCreatePasswordResetTokenSchema(marshmallow.Schema):
 class CustomerDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerDraft`."
     customer_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerNumber"
+        allow_none=True, missing=None, data_key="customerNumber", attribute="customerNumber"
     )
     email = marshmallow.fields.String(allow_none=True)
     password = marshmallow.fields.String(allow_none=True)
     first_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="firstName"
+        allow_none=True, missing=None, data_key="firstName", attribute="firstName"
     )
     last_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lastName"
+        allow_none=True, missing=None, data_key="lastName", attribute="lastName"
     )
     middle_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="middleName"
+        allow_none=True, missing=None, data_key="middleName", attribute="middleName"
     )
     title = marshmallow.fields.String(allow_none=True, missing=None)
     anonymous_cart_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousCartId"
+        allow_none=True, missing=None, data_key="anonymousCartId", attribute="anonymousCartId"
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     date_of_birth = marshmallow.fields.Date(
-        allow_none=True, missing=None, data_key="dateOfBirth"
+        allow_none=True, missing=None, data_key="dateOfBirth", attribute="dateOfBirth"
     )
     company_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="companyName"
+        allow_none=True, missing=None, data_key="companyName", attribute="companyName"
     )
-    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId")
+    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId", attribute="vatId")
     addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -139,26 +139,28 @@ class CustomerDraftSchema(marshmallow.Schema):
         missing=None,
     )
     default_shipping_address = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="defaultShippingAddress"
+        allow_none=True, missing=None, data_key="defaultShippingAddress", attribute="defaultShippingAddress"
     )
     shipping_addresses = marshmallow.fields.List(
         marshmallow.fields.Integer(allow_none=True),
         missing=None,
         data_key="shippingAddresses",
+        attribute="shippingAddresses",
     )
     default_billing_address = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="defaultBillingAddress"
+        allow_none=True, missing=None, data_key="defaultBillingAddress", attribute="defaultBillingAddress"
     )
     billing_addresses = marshmallow.fields.List(
         marshmallow.fields.Integer(allow_none=True),
         missing=None,
         data_key="billingAddresses",
+        attribute="billingAddresses",
     )
     is_email_verified = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isEmailVerified"
+        allow_none=True, missing=None, data_key="isEmailVerified", attribute="isEmailVerified"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupResourceIdentifierSchema",
@@ -166,6 +168,7 @@ class CustomerDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -188,7 +191,7 @@ class CustomerDraftSchema(marshmallow.Schema):
 class CustomerEmailVerifySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerEmailVerify`."
     version = marshmallow.fields.Integer(allow_none=True, missing=None)
-    token_value = marshmallow.fields.String(allow_none=True, data_key="tokenValue")
+    token_value = marshmallow.fields.String(allow_none=True, data_key="tokenValue", attribute="tokenValue")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -238,8 +241,8 @@ class CustomerReferenceSchema(ReferenceSchema):
 
 class CustomerResetPasswordSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerResetPassword`."
-    token_value = marshmallow.fields.String(allow_none=True, data_key="tokenValue")
-    new_password = marshmallow.fields.String(allow_none=True, data_key="newPassword")
+    token_value = marshmallow.fields.String(allow_none=True, data_key="tokenValue", attribute="tokenValue")
+    new_password = marshmallow.fields.String(allow_none=True, data_key="newPassword", attribute="newPassword")
     version = marshmallow.fields.Integer(allow_none=True, missing=None)
 
     class Meta:
@@ -265,27 +268,27 @@ class CustomerResourceIdentifierSchema(ResourceIdentifierSchema):
 class CustomerSchema(LoggedResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.Customer`."
     customer_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerNumber"
+        allow_none=True, missing=None, data_key="customerNumber", attribute="customerNumber"
     )
     email = marshmallow.fields.String(allow_none=True)
     password = marshmallow.fields.String(allow_none=True)
     first_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="firstName"
+        allow_none=True, missing=None, data_key="firstName", attribute="firstName"
     )
     last_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lastName"
+        allow_none=True, missing=None, data_key="lastName", attribute="lastName"
     )
     middle_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="middleName"
+        allow_none=True, missing=None, data_key="middleName", attribute="middleName"
     )
     title = marshmallow.fields.String(allow_none=True, missing=None)
     date_of_birth = marshmallow.fields.Date(
-        allow_none=True, missing=None, data_key="dateOfBirth"
+        allow_none=True, missing=None, data_key="dateOfBirth", attribute="dateOfBirth"
     )
     company_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="companyName"
+        allow_none=True, missing=None, data_key="companyName", attribute="companyName"
     )
-    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId")
+    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId", attribute="vatId")
     addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -293,26 +296,28 @@ class CustomerSchema(LoggedResourceSchema):
         many=True,
     )
     default_shipping_address_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="defaultShippingAddressId"
+        allow_none=True, missing=None, data_key="defaultShippingAddressId", attribute="defaultShippingAddressId"
     )
     shipping_address_ids = marshmallow.fields.List(
         marshmallow.fields.String(allow_none=True),
         missing=None,
         data_key="shippingAddressIds",
+        attribute="shippingAddressIds",
     )
     default_billing_address_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="defaultBillingAddressId"
+        allow_none=True, missing=None, data_key="defaultBillingAddressId", attribute="defaultBillingAddressId"
     )
     billing_address_ids = marshmallow.fields.List(
         marshmallow.fields.String(allow_none=True),
         missing=None,
         data_key="billingAddressIds",
+        attribute="billingAddressIds",
     )
     is_email_verified = marshmallow.fields.Bool(
-        allow_none=True, data_key="isEmailVerified"
+        allow_none=True, data_key="isEmailVerified", attribute="isEmailVerified"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupReferenceSchema",
@@ -320,6 +325,7 @@ class CustomerSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -361,16 +367,17 @@ class CustomerSigninSchema(marshmallow.Schema):
     email = marshmallow.fields.String(allow_none=True)
     password = marshmallow.fields.String(allow_none=True)
     anonymous_cart_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousCartId"
+        allow_none=True, missing=None, data_key="anonymousCartId", attribute="anonymousCartId"
     )
     anonymous_cart_sign_in_mode = marshmallow_enum.EnumField(
         types.AnonymousCartSignInMode,
         by_value=True,
         missing=None,
         data_key="anonymousCartSignInMode",
+        attribute="anonymousCartSignInMode",
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -384,12 +391,12 @@ class CustomerSigninSchema(marshmallow.Schema):
 class CustomerTokenSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerToken`."
     id = marshmallow.fields.String(allow_none=True)
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     last_modified_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="lastModifiedAt"
+        allow_none=True, missing=None, data_key="lastModifiedAt", attribute="lastModifiedAt"
     )
-    customer_id = marshmallow.fields.String(allow_none=True, data_key="customerId")
-    expires_at = marshmallow.fields.DateTime(allow_none=True, data_key="expiresAt")
+    customer_id = marshmallow.fields.String(allow_none=True, data_key="customerId", attribute="customerId")
+    expires_at = marshmallow.fields.DateTime(allow_none=True, data_key="expiresAt", attribute="expiresAt")
     value = marshmallow.fields.String(allow_none=True)
 
     class Meta:
@@ -479,7 +486,7 @@ class CustomerAddAddressActionSchema(CustomerUpdateActionSchema):
 
 class CustomerAddBillingAddressIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerAddBillingAddressIdAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -492,7 +499,7 @@ class CustomerAddBillingAddressIdActionSchema(CustomerUpdateActionSchema):
 
 class CustomerAddShippingAddressIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerAddShippingAddressIdAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -505,7 +512,7 @@ class CustomerAddShippingAddressIdActionSchema(CustomerUpdateActionSchema):
 
 class CustomerChangeAddressActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerChangeAddressAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
     address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -536,7 +543,7 @@ class CustomerChangeEmailActionSchema(CustomerUpdateActionSchema):
 
 class CustomerRemoveAddressActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerRemoveAddressAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -549,7 +556,7 @@ class CustomerRemoveAddressActionSchema(CustomerUpdateActionSchema):
 
 class CustomerRemoveBillingAddressIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerRemoveBillingAddressIdAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -562,7 +569,7 @@ class CustomerRemoveBillingAddressIdActionSchema(CustomerUpdateActionSchema):
 
 class CustomerRemoveShippingAddressIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerRemoveShippingAddressIdAction`."
-    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId")
+    address_id = marshmallow.fields.String(allow_none=True, data_key="addressId", attribute="addressId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -576,7 +583,7 @@ class CustomerRemoveShippingAddressIdActionSchema(CustomerUpdateActionSchema):
 class CustomerSetCompanyNameActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetCompanyNameAction`."
     company_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="companyName"
+        allow_none=True, missing=None, data_key="companyName", attribute="companyName"
     )
 
     class Meta:
@@ -629,6 +636,7 @@ class CustomerSetCustomerGroupActionSchema(CustomerUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
 
     class Meta:
@@ -643,7 +651,7 @@ class CustomerSetCustomerGroupActionSchema(CustomerUpdateActionSchema):
 class CustomerSetCustomerNumberActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetCustomerNumberAction`."
     customer_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerNumber"
+        allow_none=True, missing=None, data_key="customerNumber", attribute="customerNumber"
     )
 
     class Meta:
@@ -658,7 +666,7 @@ class CustomerSetCustomerNumberActionSchema(CustomerUpdateActionSchema):
 class CustomerSetDateOfBirthActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetDateOfBirthAction`."
     date_of_birth = marshmallow.fields.Date(
-        allow_none=True, missing=None, data_key="dateOfBirth"
+        allow_none=True, missing=None, data_key="dateOfBirth", attribute="dateOfBirth"
     )
 
     class Meta:
@@ -673,7 +681,7 @@ class CustomerSetDateOfBirthActionSchema(CustomerUpdateActionSchema):
 class CustomerSetDefaultBillingAddressActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetDefaultBillingAddressAction`."
     address_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="addressId"
+        allow_none=True, missing=None, data_key="addressId", attribute="addressId"
     )
 
     class Meta:
@@ -688,7 +696,7 @@ class CustomerSetDefaultBillingAddressActionSchema(CustomerUpdateActionSchema):
 class CustomerSetDefaultShippingAddressActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetDefaultShippingAddressAction`."
     address_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="addressId"
+        allow_none=True, missing=None, data_key="addressId", attribute="addressId"
     )
 
     class Meta:
@@ -703,7 +711,7 @@ class CustomerSetDefaultShippingAddressActionSchema(CustomerUpdateActionSchema):
 class CustomerSetExternalIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetExternalIdAction`."
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
 
     class Meta:
@@ -718,7 +726,7 @@ class CustomerSetExternalIdActionSchema(CustomerUpdateActionSchema):
 class CustomerSetFirstNameActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetFirstNameAction`."
     first_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="firstName"
+        allow_none=True, missing=None, data_key="firstName", attribute="firstName"
     )
 
     class Meta:
@@ -746,7 +754,7 @@ class CustomerSetKeyActionSchema(CustomerUpdateActionSchema):
 class CustomerSetLastNameActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetLastNameAction`."
     last_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lastName"
+        allow_none=True, missing=None, data_key="lastName", attribute="lastName"
     )
 
     class Meta:
@@ -774,7 +782,7 @@ class CustomerSetLocaleActionSchema(CustomerUpdateActionSchema):
 class CustomerSetMiddleNameActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetMiddleNameAction`."
     middle_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="middleName"
+        allow_none=True, missing=None, data_key="middleName", attribute="middleName"
     )
 
     class Meta:
@@ -814,7 +822,7 @@ class CustomerSetTitleActionSchema(CustomerUpdateActionSchema):
 
 class CustomerSetVatIdActionSchema(CustomerUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerSetVatIdAction`."
-    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId")
+    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId", attribute="vatId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/schemas/_customer_group.py
+++ b/src/commercetools/schemas/_customer_group.py
@@ -28,7 +28,7 @@ __all__ = [
 class CustomerGroupDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.CustomerGroupDraft`."
     key = marshmallow.fields.String(allow_none=True, missing=None)
-    group_name = marshmallow.fields.String(allow_none=True, data_key="groupName")
+    group_name = marshmallow.fields.String(allow_none=True, data_key="groupName", attribute="groupName")
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
         unknown=marshmallow.EXCLUDE,

--- a/src/commercetools/schemas/_discount_code.py
+++ b/src/commercetools/schemas/_discount_code.py
@@ -46,18 +46,19 @@ class DiscountCodeDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="cartDiscounts",
+        attribute="cartDiscounts",
     )
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="cartPredicate"
+        allow_none=True, missing=None, data_key="cartPredicate", attribute="cartPredicate"
     )
     is_active = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isActive"
+        allow_none=True, missing=None, data_key="isActive", attribute="isActive"
     )
     max_applications = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplications"
+        allow_none=True, missing=None, data_key="maxApplications", attribute="maxApplications"
     )
     max_applications_per_customer = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer"
+        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer", attribute="maxApplicationsPerCustomer"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -75,10 +76,10 @@ class DiscountCodeDraftSchema(marshmallow.Schema):
         missing=None,
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -150,11 +151,12 @@ class DiscountCodeSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="cartDiscounts",
+        attribute="cartDiscounts",
     )
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="cartPredicate"
+        allow_none=True, missing=None, data_key="cartPredicate", attribute="cartPredicate"
     )
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
     references = marshmallow.fields.List(
         helpers.Discriminator(
             discriminator_field=("typeId", "type_id"),
@@ -188,10 +190,10 @@ class DiscountCodeSchema(LoggedResourceSchema):
         )
     )
     max_applications = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplications"
+        allow_none=True, missing=None, data_key="maxApplications", attribute="maxApplications"
     )
     max_applications_per_customer = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer"
+        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer", attribute="maxApplicationsPerCustomer"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -201,10 +203,10 @@ class DiscountCodeSchema(LoggedResourceSchema):
     )
     groups = marshmallow.fields.List(marshmallow.fields.String(allow_none=True))
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -271,6 +273,7 @@ class DiscountCodeChangeCartDiscountsActionSchema(DiscountCodeUpdateActionSchema
         allow_none=True,
         many=True,
         data_key="cartDiscounts",
+        attribute="cartDiscounts",
     )
 
     class Meta:
@@ -297,7 +300,7 @@ class DiscountCodeChangeGroupsActionSchema(DiscountCodeUpdateActionSchema):
 
 class DiscountCodeChangeIsActiveActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeChangeIsActiveAction`."
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -311,7 +314,7 @@ class DiscountCodeChangeIsActiveActionSchema(DiscountCodeUpdateActionSchema):
 class DiscountCodeSetCartPredicateActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetCartPredicateAction`."
     cart_predicate = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="cartPredicate"
+        allow_none=True, missing=None, data_key="cartPredicate", attribute="cartPredicate"
     )
 
     class Meta:
@@ -372,7 +375,7 @@ class DiscountCodeSetDescriptionActionSchema(DiscountCodeUpdateActionSchema):
 class DiscountCodeSetMaxApplicationsActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetMaxApplicationsAction`."
     max_applications = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplications"
+        allow_none=True, missing=None, data_key="maxApplications", attribute="maxApplications"
     )
 
     class Meta:
@@ -389,7 +392,7 @@ class DiscountCodeSetMaxApplicationsPerCustomerActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetMaxApplicationsPerCustomerAction`."
     max_applications_per_customer = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer"
+        allow_none=True, missing=None, data_key="maxApplicationsPerCustomer", attribute="maxApplicationsPerCustomer"
     )
 
     class Meta:
@@ -417,7 +420,7 @@ class DiscountCodeSetNameActionSchema(DiscountCodeUpdateActionSchema):
 class DiscountCodeSetValidFromActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetValidFromAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
 
     class Meta:
@@ -432,10 +435,10 @@ class DiscountCodeSetValidFromActionSchema(DiscountCodeUpdateActionSchema):
 class DiscountCodeSetValidFromAndUntilActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetValidFromAndUntilAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -450,7 +453,7 @@ class DiscountCodeSetValidFromAndUntilActionSchema(DiscountCodeUpdateActionSchem
 class DiscountCodeSetValidUntilActionSchema(DiscountCodeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeSetValidUntilAction`."
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_error.py
+++ b/src/commercetools/schemas/_error.py
@@ -75,7 +75,7 @@ class ErrorObjectSchema(marshmallow.Schema):
 
 class ErrorResponseSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ErrorResponse`."
-    status_code = marshmallow.fields.Integer(allow_none=True, data_key="statusCode")
+    status_code = marshmallow.fields.Integer(allow_none=True, data_key="statusCode", attribute="statusCode")
     message = marshmallow.fields.String(allow_none=True)
     error = marshmallow.fields.String(allow_none=True, missing=None)
     error_description = marshmallow.fields.String(allow_none=True, missing=None)
@@ -170,7 +170,7 @@ class AccessDeniedErrorSchema(ErrorObjectSchema):
 class ConcurrentModificationErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.ConcurrentModificationError`."
     current_version = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="currentVersion"
+        allow_none=True, missing=None, data_key="currentVersion", attribute="currentVersion"
     )
 
     class Meta:
@@ -185,20 +185,20 @@ class ConcurrentModificationErrorSchema(ErrorObjectSchema):
 class DiscountCodeNonApplicableErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.DiscountCodeNonApplicableError`."
     discount_code = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="discountCode"
+        allow_none=True, missing=None, data_key="discountCode", attribute="discountCode"
     )
     reason = marshmallow.fields.String(allow_none=True, missing=None)
     dicount_code_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="dicountCodeId"
+        allow_none=True, missing=None, data_key="dicountCodeId", attribute="dicountCodeId"
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
     validity_check_time = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validityCheckTime"
+        allow_none=True, missing=None, data_key="validityCheckTime", attribute="validityCheckTime"
     )
 
     class Meta:
@@ -249,7 +249,7 @@ class DuplicateFieldErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.DuplicateFieldError`."
     field = marshmallow.fields.String(allow_none=True, missing=None)
     duplicate_value = marshmallow.fields.Raw(
-        allow_none=True, missing=None, data_key="duplicateValue"
+        allow_none=True, missing=None, data_key="duplicateValue", attribute="duplicateValue"
     )
 
     class Meta:
@@ -264,7 +264,7 @@ class DuplicateFieldErrorSchema(ErrorObjectSchema):
 class DuplicateFieldWithConflictingResourceErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.DuplicateFieldWithConflictingResourceError`."
     field = marshmallow.fields.String(allow_none=True)
-    duplicate_value = marshmallow.fields.Raw(allow_none=True, data_key="duplicateValue")
+    duplicate_value = marshmallow.fields.Raw(allow_none=True, data_key="duplicateValue", attribute="duplicateValue")
     conflicting_resource = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
         discriminator_schemas={
@@ -295,6 +295,7 @@ class DuplicateFieldWithConflictingResourceErrorSchema(ErrorObjectSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="conflictingResource",
+        attribute="conflictingResource",
     )
 
     class Meta:
@@ -314,6 +315,7 @@ class DuplicatePriceScopeErrorSchema(ErrorObjectSchema):
         allow_none=True,
         many=True,
         data_key="conflictingPrices",
+        attribute="conflictingPrices",
     )
 
     class Meta:
@@ -332,6 +334,7 @@ class DuplicateVariantValuesErrorSchema(ErrorObjectSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="variantValues",
+        attribute="variantValues",
     )
 
     class Meta:
@@ -358,16 +361,17 @@ class EnumValueIsUsedErrorSchema(ErrorObjectSchema):
 class ExtensionBadResponseErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionBadResponseError`."
     localized_message = LocalizedStringField(
-        allow_none=True, missing=None, data_key="localizedMessage"
+        allow_none=True, missing=None, data_key="localizedMessage", attribute="localizedMessage"
     )
     extension_extra_info = marshmallow.fields.Dict(
-        allow_none=True, missing=None, data_key="extensionExtraInfo"
+        allow_none=True, missing=None, data_key="extensionExtraInfo", attribute="extensionExtraInfo"
     )
     error_by_extension = marshmallow.fields.Nested(
         nested="commercetools.schemas._error.ErrorByExtensionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="errorByExtension",
+        attribute="errorByExtension",
     )
 
     class Meta:
@@ -382,16 +386,17 @@ class ExtensionBadResponseErrorSchema(ErrorObjectSchema):
 class ExtensionNoResponseErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionNoResponseError`."
     localized_message = LocalizedStringField(
-        allow_none=True, missing=None, data_key="localizedMessage"
+        allow_none=True, missing=None, data_key="localizedMessage", attribute="localizedMessage"
     )
     extension_extra_info = marshmallow.fields.Dict(
-        allow_none=True, missing=None, data_key="extensionExtraInfo"
+        allow_none=True, missing=None, data_key="extensionExtraInfo", attribute="extensionExtraInfo"
     )
     error_by_extension = marshmallow.fields.Nested(
         nested="commercetools.schemas._error.ErrorByExtensionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="errorByExtension",
+        attribute="errorByExtension",
     )
 
     class Meta:
@@ -406,16 +411,17 @@ class ExtensionNoResponseErrorSchema(ErrorObjectSchema):
 class ExtensionUpdateActionsFailedErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionUpdateActionsFailedError`."
     localized_message = LocalizedStringField(
-        allow_none=True, missing=None, data_key="localizedMessage"
+        allow_none=True, missing=None, data_key="localizedMessage", attribute="localizedMessage"
     )
     extension_extra_info = marshmallow.fields.Dict(
-        allow_none=True, missing=None, data_key="extensionExtraInfo"
+        allow_none=True, missing=None, data_key="extensionExtraInfo", attribute="extensionExtraInfo"
     )
     error_by_extension = marshmallow.fields.Nested(
         nested="commercetools.schemas._error.ErrorByExtensionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="errorByExtension",
+        attribute="errorByExtension",
     )
 
     class Meta:
@@ -466,7 +472,7 @@ class InvalidCurrentPasswordErrorSchema(ErrorObjectSchema):
 class InvalidFieldErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.InvalidFieldError`."
     field = marshmallow.fields.String(allow_none=True)
-    invalid_value = marshmallow.fields.Raw(allow_none=True, data_key="invalidValue")
+    invalid_value = marshmallow.fields.Raw(allow_none=True, data_key="invalidValue", attribute="invalidValue")
     allowed_values = marshmallow.fields.List(
         marshmallow.fields.Nested(
             nested="commercetools.schemas.None.anySchema",
@@ -476,6 +482,7 @@ class InvalidFieldErrorSchema(ErrorObjectSchema):
         allow_none=True,
         missing=None,
         data_key="allowedValues",
+        attribute="allowedValues",
     )
 
     class Meta:
@@ -502,7 +509,7 @@ class InvalidInputErrorSchema(ErrorObjectSchema):
 class InvalidItemShippingDetailsErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.InvalidItemShippingDetailsError`."
     subject = marshmallow.fields.String(allow_none=True)
-    item_id = marshmallow.fields.String(allow_none=True, data_key="itemId")
+    item_id = marshmallow.fields.String(allow_none=True, data_key="itemId", attribute="itemId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -563,8 +570,8 @@ class InvalidTokenErrorSchema(ErrorObjectSchema):
 
 class MatchingPriceNotFoundErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.MatchingPriceNotFoundError`."
-    product_id = marshmallow.fields.String(allow_none=True, data_key="productId")
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    product_id = marshmallow.fields.String(allow_none=True, data_key="productId", attribute="productId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     currency = marshmallow.fields.String(allow_none=True, missing=None)
     country = marshmallow.fields.String(allow_none=True, missing=None)
     customer_group = marshmallow.fields.Nested(
@@ -573,6 +580,7 @@ class MatchingPriceNotFoundErrorSchema(ErrorObjectSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelReferenceSchema",
@@ -593,7 +601,7 @@ class MatchingPriceNotFoundErrorSchema(ErrorObjectSchema):
 class MissingTaxRateForCountryErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.MissingTaxRateForCountryError`."
     tax_category_id = marshmallow.fields.String(
-        allow_none=True, data_key="taxCategoryId"
+        allow_none=True, data_key="taxCategoryId", attribute="taxCategoryId"
     )
     country = marshmallow.fields.String(allow_none=True, missing=None)
     state = marshmallow.fields.String(allow_none=True, missing=None)
@@ -622,7 +630,7 @@ class NoMatchingProductDiscountFoundErrorSchema(ErrorObjectSchema):
 class OutOfStockErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.OutOfStockError`."
     line_items = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="lineItems"
+        marshmallow.fields.String(allow_none=True), data_key="lineItems", attribute="lineItems"
     )
     skus = marshmallow.fields.List(marshmallow.fields.String(allow_none=True))
 
@@ -638,7 +646,7 @@ class OutOfStockErrorSchema(ErrorObjectSchema):
 class PriceChangedErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.PriceChangedError`."
     line_items = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="lineItems"
+        marshmallow.fields.String(allow_none=True), data_key="lineItems", attribute="lineItems"
     )
     shipping = marshmallow.fields.Bool(allow_none=True)
 
@@ -654,7 +662,7 @@ class PriceChangedErrorSchema(ErrorObjectSchema):
 class ReferenceExistsErrorSchema(ErrorObjectSchema):
     "Marshmallow schema for :class:`commercetools.types.ReferenceExistsError`."
     referenced_by = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, missing=None, data_key="referencedBy"
+        types.ReferenceTypeId, by_value=True, missing=None, data_key="referencedBy", attribute="referencedBy"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_extension.py
+++ b/src/commercetools/schemas/_extension.py
@@ -59,7 +59,7 @@ class ExtensionDraftSchema(marshmallow.Schema):
         many=True,
     )
     timeout_in_ms = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="timeoutInMs"
+        allow_none=True, missing=None, data_key="timeoutInMs", attribute="timeoutInMs"
     )
 
     class Meta:
@@ -164,7 +164,7 @@ class ExtensionSchema(LoggedResourceSchema):
         many=True,
     )
     timeout_in_ms = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="timeoutInMs"
+        allow_none=True, missing=None, data_key="timeoutInMs", attribute="timeoutInMs"
     )
 
     class Meta:
@@ -178,7 +178,7 @@ class ExtensionSchema(LoggedResourceSchema):
 class ExtensionTriggerSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionTrigger`."
     resource_type_id = marshmallow_enum.EnumField(
-        types.ExtensionResourceTypeId, by_value=True, data_key="resourceTypeId"
+        types.ExtensionResourceTypeId, by_value=True, data_key="resourceTypeId", attribute="resourceTypeId"
     )
     actions = marshmallow.fields.List(
         marshmallow_enum.EnumField(types.ExtensionAction, by_value=True)
@@ -234,8 +234,8 @@ class ExtensionUpdateSchema(marshmallow.Schema):
 class ExtensionAWSLambdaDestinationSchema(ExtensionDestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionAWSLambdaDestination`."
     arn = marshmallow.fields.String(allow_none=True)
-    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey")
-    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret")
+    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey", attribute="accessKey")
+    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret", attribute="accessSecret")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -250,7 +250,7 @@ class ExtensionAuthorizationHeaderAuthenticationSchema(
     ExtensionHttpDestinationAuthenticationSchema
 ):
     "Marshmallow schema for :class:`commercetools.types.ExtensionAuthorizationHeaderAuthentication`."
-    header_value = marshmallow.fields.String(allow_none=True, data_key="headerValue")
+    header_value = marshmallow.fields.String(allow_none=True, data_key="headerValue", attribute="headerValue")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -354,7 +354,7 @@ class ExtensionSetKeyActionSchema(ExtensionUpdateActionSchema):
 class ExtensionSetTimeoutInMsActionSchema(ExtensionUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ExtensionSetTimeoutInMsAction`."
     timeout_in_ms = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="timeoutInMs"
+        allow_none=True, missing=None, data_key="timeoutInMs", attribute="timeoutInMs"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_inventory.py
+++ b/src/commercetools/schemas/_inventory.py
@@ -38,15 +38,16 @@ class InventoryEntryDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     quantity_on_stock = marshmallow.fields.Integer(
-        allow_none=True, data_key="quantityOnStock"
+        allow_none=True, data_key="quantityOnStock", attribute="quantityOnStock"
     )
     restockable_in_days = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="restockableInDays"
+        allow_none=True, missing=None, data_key="restockableInDays", attribute="restockableInDays"
     )
     expected_delivery = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="expectedDelivery"
+        allow_none=True, missing=None, data_key="expectedDelivery", attribute="expectedDelivery"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -102,18 +103,19 @@ class InventoryEntrySchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     quantity_on_stock = marshmallow.fields.Integer(
-        allow_none=True, data_key="quantityOnStock"
+        allow_none=True, data_key="quantityOnStock", attribute="quantityOnStock"
     )
     available_quantity = marshmallow.fields.Integer(
-        allow_none=True, data_key="availableQuantity"
+        allow_none=True, data_key="availableQuantity", attribute="availableQuantity"
     )
     restockable_in_days = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="restockableInDays"
+        allow_none=True, missing=None, data_key="restockableInDays", attribute="restockableInDays"
     )
     expected_delivery = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="expectedDelivery"
+        allow_none=True, missing=None, data_key="expectedDelivery", attribute="expectedDelivery"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -268,7 +270,7 @@ class InventorySetCustomTypeActionSchema(InventoryUpdateActionSchema):
 class InventorySetExpectedDeliveryActionSchema(InventoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.InventorySetExpectedDeliveryAction`."
     expected_delivery = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="expectedDelivery"
+        allow_none=True, missing=None, data_key="expectedDelivery", attribute="expectedDelivery"
     )
 
     class Meta:
@@ -283,7 +285,7 @@ class InventorySetExpectedDeliveryActionSchema(InventoryUpdateActionSchema):
 class InventorySetRestockableInDaysActionSchema(InventoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.InventorySetRestockableInDaysAction`."
     restockable_in_days = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="restockableInDays"
+        allow_none=True, missing=None, data_key="restockableInDays", attribute="restockableInDays"
     )
 
     class Meta:
@@ -303,6 +305,7 @@ class InventorySetSupplyChannelActionSchema(InventoryUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_me.py
+++ b/src/commercetools/schemas/_me.py
@@ -17,11 +17,11 @@ class MyCartDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.MyCartDraft`."
     currency = marshmallow.fields.String()
     customer_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerEmail"
+        allow_none=True, missing=None, data_key="customerEmail", attribute="customerEmail"
     )
     country = marshmallow.fields.String(allow_none=True, missing=None)
     inventory_mode = marshmallow_enum.EnumField(
-        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode"
+        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode", attribute="inventoryMode"
     )
     line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._me.MyLineItemDraftSchema",
@@ -30,6 +30,7 @@ class MyCartDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="lineItems",
+        attribute="lineItems",
     )
     shipping_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -37,6 +38,7 @@ class MyCartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingAddress",
+        attribute="shippingAddress",
     )
     billing_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -44,6 +46,7 @@ class MyCartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="billingAddress",
+        attribute="billingAddress",
     )
     shipping_method = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingMethodResourceIdentifierSchema",
@@ -51,6 +54,7 @@ class MyCartDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -60,10 +64,10 @@ class MyCartDraftSchema(marshmallow.Schema):
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, missing=None, data_key="taxMode"
+        types.TaxMode, by_value=True, missing=None, data_key="taxMode", attribute="taxMode"
     )
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
     item_shipping_addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -72,6 +76,7 @@ class MyCartDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="itemShippingAddresses",
+        attribute="itemShippingAddresses",
     )
 
     class Meta:
@@ -87,22 +92,22 @@ class MyCustomerDraftSchema(marshmallow.Schema):
     email = marshmallow.fields.String(allow_none=True)
     password = marshmallow.fields.String(allow_none=True)
     first_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="firstName"
+        allow_none=True, missing=None, data_key="firstName", attribute="firstName"
     )
     last_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lastName"
+        allow_none=True, missing=None, data_key="lastName", attribute="lastName"
     )
     middle_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="middleName"
+        allow_none=True, missing=None, data_key="middleName", attribute="middleName"
     )
     title = marshmallow.fields.String(allow_none=True, missing=None)
     date_of_birth = marshmallow.fields.Date(
-        allow_none=True, missing=None, data_key="dateOfBirth"
+        allow_none=True, missing=None, data_key="dateOfBirth", attribute="dateOfBirth"
     )
     company_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="companyName"
+        allow_none=True, missing=None, data_key="companyName", attribute="companyName"
     )
-    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId")
+    vat_id = marshmallow.fields.String(allow_none=True, missing=None, data_key="vatId", attribute="vatId")
     addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -111,10 +116,10 @@ class MyCustomerDraftSchema(marshmallow.Schema):
         missing=None,
     )
     default_shipping_address = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="defaultShippingAddress"
+        allow_none=True, missing=None, data_key="defaultShippingAddress", attribute="defaultShippingAddress"
     )
     default_billing_address = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="defaultBillingAddress"
+        allow_none=True, missing=None, data_key="defaultBillingAddress", attribute="defaultBillingAddress"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -134,8 +139,8 @@ class MyCustomerDraftSchema(marshmallow.Schema):
 
 class MyLineItemDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.MyLineItemDraft`."
-    product_id = marshmallow.fields.String(allow_none=True, data_key="productId")
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    product_id = marshmallow.fields.String(allow_none=True, data_key="productId", attribute="productId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     quantity = marshmallow.fields.Integer(allow_none=True)
     supply_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -143,6 +148,7 @@ class MyLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -150,6 +156,7 @@ class MyLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -163,6 +170,7 @@ class MyLineItemDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_message.py
+++ b/src/commercetools/schemas/_message.py
@@ -149,7 +149,7 @@ class MessageConfigurationDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.MessageConfigurationDraft`."
     enabled = marshmallow.fields.Bool(allow_none=True)
     delete_days_after_creation = marshmallow.fields.Integer(
-        allow_none=True, data_key="deleteDaysAfterCreation"
+        allow_none=True, data_key="deleteDaysAfterCreation", attribute="deleteDaysAfterCreation"
     )
 
     class Meta:
@@ -164,7 +164,7 @@ class MessageConfigurationSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.MessageConfiguration`."
     enabled = marshmallow.fields.Bool(allow_none=True)
     delete_days_after_creation = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterCreation"
+        allow_none=True, missing=None, data_key="deleteDaysAfterCreation", attribute="deleteDaysAfterCreation"
     )
 
     class Meta:
@@ -211,7 +211,7 @@ class MessagePayloadSchema(marshmallow.Schema):
 class MessageSchema(BaseResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.Message`."
     sequence_number = marshmallow.fields.Integer(
-        allow_none=True, data_key="sequenceNumber"
+        allow_none=True, data_key="sequenceNumber", attribute="sequenceNumber"
     )
     resource = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
@@ -244,7 +244,7 @@ class MessageSchema(BaseResourceSchema):
         allow_none=True,
     )
     resource_version = marshmallow.fields.Integer(
-        allow_none=True, data_key="resourceVersion"
+        allow_none=True, data_key="resourceVersion", attribute="resourceVersion"
     )
     type = marshmallow.fields.String(allow_none=True)
     resource_user_provided_identifiers = marshmallow.fields.Nested(
@@ -253,6 +253,7 @@ class MessageSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="resourceUserProvidedIdentifiers",
+        attribute="resourceUserProvidedIdentifiers",
     )
 
     class Meta:
@@ -265,12 +266,12 @@ class MessageSchema(BaseResourceSchema):
 
 class ProductPriceDiscountsSetUpdatedPriceSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ProductPriceDiscountsSetUpdatedPrice`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     variant_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="variantKey"
+        allow_none=True, missing=None, data_key="variantKey", attribute="variantKey"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
         unknown=marshmallow.EXCLUDE,
@@ -291,13 +292,13 @@ class UserProvidedIdentifiersSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.UserProvidedIdentifiers`."
     key = marshmallow.fields.String(allow_none=True, missing=None)
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
     customer_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerNumber"
+        allow_none=True, missing=None, data_key="customerNumber", attribute="customerNumber"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     slug = LocalizedStringField(allow_none=True, missing=None)
@@ -371,10 +372,10 @@ class CategorySlugChangedMessageSchema(MessageSchema):
 class CustomLineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomLineItemStateTransitionMessagePayload`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     transition_date = marshmallow.fields.DateTime(
-        allow_none=True, data_key="transitionDate"
+        allow_none=True, data_key="transitionDate", attribute="transitionDate"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -382,12 +383,14 @@ class CustomLineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
 
     class Meta:
@@ -402,10 +405,10 @@ class CustomLineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
 class CustomLineItemStateTransitionMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomLineItemStateTransitionMessage`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     transition_date = marshmallow.fields.DateTime(
-        allow_none=True, data_key="transitionDate"
+        allow_none=True, data_key="transitionDate", attribute="transitionDate"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -413,12 +416,14 @@ class CustomLineItemStateTransitionMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
 
     class Meta:
@@ -530,7 +535,7 @@ class CustomerAddressRemovedMessageSchema(MessageSchema):
 
 class CustomerCompanyNameSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerCompanyNameSetMessagePayload`."
-    company_name = marshmallow.fields.String(allow_none=True, data_key="companyName")
+    company_name = marshmallow.fields.String(allow_none=True, data_key="companyName", attribute="companyName")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -543,7 +548,7 @@ class CustomerCompanyNameSetMessagePayloadSchema(MessagePayloadSchema):
 
 class CustomerCompanyNameSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerCompanyNameSetMessage`."
-    company_name = marshmallow.fields.String(allow_none=True, data_key="companyName")
+    company_name = marshmallow.fields.String(allow_none=True, data_key="companyName", attribute="companyName")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -588,7 +593,7 @@ class CustomerCreatedMessageSchema(MessageSchema):
 
 class CustomerDateOfBirthSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerDateOfBirthSetMessagePayload`."
-    date_of_birth = marshmallow.fields.Date(allow_none=True, data_key="dateOfBirth")
+    date_of_birth = marshmallow.fields.Date(allow_none=True, data_key="dateOfBirth", attribute="dateOfBirth")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -601,7 +606,7 @@ class CustomerDateOfBirthSetMessagePayloadSchema(MessagePayloadSchema):
 
 class CustomerDateOfBirthSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomerDateOfBirthSetMessage`."
-    date_of_birth = marshmallow.fields.Date(allow_none=True, data_key="dateOfBirth")
+    date_of_birth = marshmallow.fields.Date(allow_none=True, data_key="dateOfBirth", attribute="dateOfBirth")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -666,6 +671,7 @@ class CustomerGroupSetMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
 
     class Meta:
@@ -684,6 +690,7 @@ class CustomerGroupSetMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
 
     class Meta:
@@ -729,7 +736,7 @@ class DeliveryAddedMessageSchema(MessageSchema):
 
 class DeliveryAddressSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.DeliveryAddressSetMessagePayload`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -742,6 +749,7 @@ class DeliveryAddressSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -755,7 +763,7 @@ class DeliveryAddressSetMessagePayloadSchema(MessagePayloadSchema):
 
 class DeliveryAddressSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.DeliveryAddressSetMessage`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -768,6 +776,7 @@ class DeliveryAddressSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -780,7 +789,7 @@ class DeliveryAddressSetMessageSchema(MessageSchema):
 
 class DeliveryItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.DeliveryItemsUpdatedMessagePayload`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -793,6 +802,7 @@ class DeliveryItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         many=True,
         data_key="oldItems",
+        attribute="oldItems",
     )
 
     class Meta:
@@ -806,7 +816,7 @@ class DeliveryItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
 
 class DeliveryItemsUpdatedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.DeliveryItemsUpdatedMessage`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -819,6 +829,7 @@ class DeliveryItemsUpdatedMessageSchema(MessageSchema):
         allow_none=True,
         many=True,
         data_key="oldItems",
+        attribute="oldItems",
     )
 
     class Meta:
@@ -870,6 +881,7 @@ class InventoryEntryDeletedMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
 
     class Meta:
@@ -889,6 +901,7 @@ class InventoryEntryDeletedMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
 
     class Meta:
@@ -901,9 +914,9 @@ class InventoryEntryDeletedMessageSchema(MessageSchema):
 
 class LineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.LineItemStateTransitionMessagePayload`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     transition_date = marshmallow.fields.DateTime(
-        allow_none=True, data_key="transitionDate"
+        allow_none=True, data_key="transitionDate", attribute="transitionDate"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -911,12 +924,14 @@ class LineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
 
     class Meta:
@@ -930,9 +945,9 @@ class LineItemStateTransitionMessagePayloadSchema(MessagePayloadSchema):
 
 class LineItemStateTransitionMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.LineItemStateTransitionMessage`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     transition_date = marshmallow.fields.DateTime(
-        allow_none=True, data_key="transitionDate"
+        allow_none=True, data_key="transitionDate", attribute="transitionDate"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -940,12 +955,14 @@ class LineItemStateTransitionMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
 
     class Meta:
@@ -970,6 +987,7 @@ class OrderBillingAddressSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -995,6 +1013,7 @@ class OrderBillingAddressSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -1041,7 +1060,7 @@ class OrderCreatedMessageSchema(MessageSchema):
 class OrderCustomLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderCustomLineItemDiscountSetMessagePayload`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
@@ -1049,6 +1068,7 @@ class OrderCustomLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedItemPriceSchema",
@@ -1056,6 +1076,7 @@ class OrderCustomLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
 
     class Meta:
@@ -1070,7 +1091,7 @@ class OrderCustomLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
 class OrderCustomLineItemDiscountSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderCustomLineItemDiscountSetMessage`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
@@ -1078,6 +1099,7 @@ class OrderCustomLineItemDiscountSetMessageSchema(MessageSchema):
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedItemPriceSchema",
@@ -1085,6 +1107,7 @@ class OrderCustomLineItemDiscountSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
 
     class Meta:
@@ -1099,7 +1122,7 @@ class OrderCustomerEmailSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderCustomerEmailSetMessagePayload`."
     email = marshmallow.fields.String(allow_none=True, missing=None)
     old_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="oldEmail"
+        allow_none=True, missing=None, data_key="oldEmail", attribute="oldEmail"
     )
 
     class Meta:
@@ -1115,7 +1138,7 @@ class OrderCustomerEmailSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderCustomerEmailSetMessage`."
     email = marshmallow.fields.String(allow_none=True, missing=None)
     old_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="oldEmail"
+        allow_none=True, missing=None, data_key="oldEmail", attribute="oldEmail"
     )
 
     class Meta:
@@ -1140,6 +1163,7 @@ class OrderCustomerSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     old_customer = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer.CustomerReferenceSchema",
@@ -1147,6 +1171,7 @@ class OrderCustomerSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldCustomer",
+        attribute="oldCustomer",
     )
     old_customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupReferenceSchema",
@@ -1154,6 +1179,7 @@ class OrderCustomerSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldCustomerGroup",
+        attribute="oldCustomerGroup",
     )
 
     class Meta:
@@ -1179,6 +1205,7 @@ class OrderCustomerSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     old_customer = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer.CustomerReferenceSchema",
@@ -1186,6 +1213,7 @@ class OrderCustomerSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldCustomer",
+        attribute="oldCustomer",
     )
     old_customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupReferenceSchema",
@@ -1193,6 +1221,7 @@ class OrderCustomerSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldCustomerGroup",
+        attribute="oldCustomerGroup",
     )
 
     class Meta:
@@ -1243,6 +1272,7 @@ class OrderDiscountCodeAddedMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
 
     class Meta:
@@ -1261,6 +1291,7 @@ class OrderDiscountCodeAddedMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
 
     class Meta:
@@ -1278,6 +1309,7 @@ class OrderDiscountCodeRemovedMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
 
     class Meta:
@@ -1296,6 +1328,7 @@ class OrderDiscountCodeRemovedMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
 
     class Meta:
@@ -1313,10 +1346,11 @@ class OrderDiscountCodeStateSetMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
     state = marshmallow_enum.EnumField(types.DiscountCodeState, by_value=True)
     old_state = marshmallow_enum.EnumField(
-        types.DiscountCodeState, by_value=True, missing=None, data_key="oldState"
+        types.DiscountCodeState, by_value=True, missing=None, data_key="oldState", attribute="oldState"
     )
 
     class Meta:
@@ -1335,10 +1369,11 @@ class OrderDiscountCodeStateSetMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
     state = marshmallow_enum.EnumField(types.DiscountCodeState, by_value=True)
     old_state = marshmallow_enum.EnumField(
-        types.DiscountCodeState, by_value=True, missing=None, data_key="oldState"
+        types.DiscountCodeState, by_value=True, missing=None, data_key="oldState", attribute="oldState"
     )
 
     class Meta:
@@ -1427,19 +1462,21 @@ class OrderImportedMessageSchema(MessageSchema):
 
 class OrderLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderLineItemDiscountSetMessagePayload`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedItemPriceSchema",
@@ -1447,6 +1484,7 @@ class OrderLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
 
     class Meta:
@@ -1460,19 +1498,21 @@ class OrderLineItemDiscountSetMessagePayloadSchema(MessagePayloadSchema):
 
 class OrderLineItemDiscountSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderLineItemDiscountSetMessage`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     discounted_price_per_quantity = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountedLineItemPriceForQuantitySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         many=True,
         data_key="discountedPricePerQuantity",
+        attribute="discountedPricePerQuantity",
     )
     total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedItemPriceSchema",
@@ -1480,6 +1520,7 @@ class OrderLineItemDiscountSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
 
     class Meta:
@@ -1493,10 +1534,10 @@ class OrderLineItemDiscountSetMessageSchema(MessageSchema):
 class OrderPaymentStateChangedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderPaymentStateChangedMessagePayload`."
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, data_key="paymentState"
+        types.PaymentState, by_value=True, data_key="paymentState", attribute="paymentState"
     )
     old_payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, data_key="oldPaymentState"
+        types.PaymentState, by_value=True, data_key="oldPaymentState", attribute="oldPaymentState"
     )
 
     class Meta:
@@ -1511,10 +1552,10 @@ class OrderPaymentStateChangedMessagePayloadSchema(MessagePayloadSchema):
 class OrderPaymentStateChangedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderPaymentStateChangedMessage`."
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, data_key="paymentState"
+        types.PaymentState, by_value=True, data_key="paymentState", attribute="paymentState"
     )
     old_payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, data_key="oldPaymentState"
+        types.PaymentState, by_value=True, data_key="oldPaymentState", attribute="oldPaymentState"
     )
 
     class Meta:
@@ -1532,6 +1573,7 @@ class OrderReturnInfoAddedMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="returnInfo",
+        attribute="returnInfo",
     )
 
     class Meta:
@@ -1550,6 +1592,7 @@ class OrderReturnInfoAddedMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="returnInfo",
+        attribute="returnInfo",
     )
 
     class Meta:
@@ -1562,9 +1605,9 @@ class OrderReturnInfoAddedMessageSchema(MessageSchema):
 
 class OrderReturnShipmentStateChangedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderReturnShipmentStateChangedMessagePayload`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     return_shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="returnShipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="returnShipmentState", attribute="returnShipmentState"
     )
 
     class Meta:
@@ -1578,9 +1621,9 @@ class OrderReturnShipmentStateChangedMessagePayloadSchema(MessagePayloadSchema):
 
 class OrderReturnShipmentStateChangedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderReturnShipmentStateChangedMessage`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     return_shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="returnShipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="returnShipmentState", attribute="returnShipmentState"
     )
 
     class Meta:
@@ -1594,10 +1637,10 @@ class OrderReturnShipmentStateChangedMessageSchema(MessageSchema):
 class OrderShipmentStateChangedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderShipmentStateChangedMessagePayload`."
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, data_key="shipmentState"
+        types.ShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
     old_shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, data_key="oldShipmentState"
+        types.ShipmentState, by_value=True, data_key="oldShipmentState", attribute="oldShipmentState"
     )
 
     class Meta:
@@ -1612,10 +1655,10 @@ class OrderShipmentStateChangedMessagePayloadSchema(MessagePayloadSchema):
 class OrderShipmentStateChangedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderShipmentStateChangedMessage`."
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, data_key="shipmentState"
+        types.ShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
     old_shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, data_key="oldShipmentState"
+        types.ShipmentState, by_value=True, data_key="oldShipmentState", attribute="oldShipmentState"
     )
 
     class Meta:
@@ -1640,6 +1683,7 @@ class OrderShippingAddressSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -1665,6 +1709,7 @@ class OrderShippingAddressSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldAddress",
+        attribute="oldAddress",
     )
 
     class Meta:
@@ -1683,6 +1728,7 @@ class OrderShippingInfoSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="shippingInfo",
+        attribute="shippingInfo",
     )
     old_shipping_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ShippingInfoSchema",
@@ -1690,6 +1736,7 @@ class OrderShippingInfoSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldShippingInfo",
+        attribute="oldShippingInfo",
     )
 
     class Meta:
@@ -1709,6 +1756,7 @@ class OrderShippingInfoSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="shippingInfo",
+        attribute="shippingInfo",
     )
     old_shipping_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ShippingInfoSchema",
@@ -1716,6 +1764,7 @@ class OrderShippingInfoSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldShippingInfo",
+        attribute="oldShippingInfo",
     )
 
     class Meta:
@@ -1738,6 +1787,7 @@ class OrderShippingRateInputSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
     old_shipping_rate_input = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -1749,6 +1799,7 @@ class OrderShippingRateInputSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         missing=None,
         data_key="oldShippingRateInput",
+        attribute="oldShippingRateInput",
     )
 
     class Meta:
@@ -1772,6 +1823,7 @@ class OrderShippingRateInputSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
     old_shipping_rate_input = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -1783,6 +1835,7 @@ class OrderShippingRateInputSetMessageSchema(MessageSchema):
         allow_none=True,
         missing=None,
         data_key="oldShippingRateInput",
+        attribute="oldShippingRateInput",
     )
 
     class Meta:
@@ -1796,10 +1849,10 @@ class OrderShippingRateInputSetMessageSchema(MessageSchema):
 class OrderStateChangedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderStateChangedMessagePayload`."
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="orderState"
+        types.OrderState, by_value=True, data_key="orderState", attribute="orderState"
     )
     old_order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="oldOrderState"
+        types.OrderState, by_value=True, data_key="oldOrderState", attribute="oldOrderState"
     )
 
     class Meta:
@@ -1814,10 +1867,10 @@ class OrderStateChangedMessagePayloadSchema(MessagePayloadSchema):
 class OrderStateChangedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderStateChangedMessage`."
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="orderState"
+        types.OrderState, by_value=True, data_key="orderState", attribute="orderState"
     )
     old_order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="oldOrderState"
+        types.OrderState, by_value=True, data_key="oldOrderState", attribute="oldOrderState"
     )
 
     class Meta:
@@ -1908,9 +1961,9 @@ class ParcelAddedToDeliveryMessageSchema(MessageSchema):
 
 class ParcelItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelItemsUpdatedMessagePayload`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     delivery_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="deliveryId"
+        allow_none=True, missing=None, data_key="deliveryId", attribute="deliveryId"
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -1924,6 +1977,7 @@ class ParcelItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         many=True,
         data_key="oldItems",
+        attribute="oldItems",
     )
 
     class Meta:
@@ -1937,9 +1991,9 @@ class ParcelItemsUpdatedMessagePayloadSchema(MessagePayloadSchema):
 
 class ParcelItemsUpdatedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelItemsUpdatedMessage`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     delivery_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="deliveryId"
+        allow_none=True, missing=None, data_key="deliveryId", attribute="deliveryId"
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -1953,6 +2007,7 @@ class ParcelItemsUpdatedMessageSchema(MessageSchema):
         allow_none=True,
         many=True,
         data_key="oldItems",
+        attribute="oldItems",
     )
 
     class Meta:
@@ -1965,8 +2020,8 @@ class ParcelItemsUpdatedMessageSchema(MessageSchema):
 
 class ParcelMeasurementsUpdatedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelMeasurementsUpdatedMessagePayload`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1985,8 +2040,8 @@ class ParcelMeasurementsUpdatedMessagePayloadSchema(MessagePayloadSchema):
 
 class ParcelMeasurementsUpdatedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelMeasurementsUpdatedMessage`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2004,7 +2059,7 @@ class ParcelMeasurementsUpdatedMessageSchema(MessageSchema):
 
 class ParcelRemovedFromDeliveryMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelRemovedFromDeliveryMessagePayload`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     parcel = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2022,7 +2077,7 @@ class ParcelRemovedFromDeliveryMessagePayloadSchema(MessagePayloadSchema):
 
 class ParcelRemovedFromDeliveryMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelRemovedFromDeliveryMessage`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     parcel = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2039,14 +2094,15 @@ class ParcelRemovedFromDeliveryMessageSchema(MessageSchema):
 
 class ParcelTrackingDataUpdatedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelTrackingDataUpdatedMessagePayload`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     tracking_data = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.TrackingDataSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
 
     class Meta:
@@ -2060,14 +2116,15 @@ class ParcelTrackingDataUpdatedMessagePayloadSchema(MessagePayloadSchema):
 
 class ParcelTrackingDataUpdatedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ParcelTrackingDataUpdatedMessage`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     tracking_data = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.TrackingDataSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
 
     class Meta:
@@ -2146,9 +2203,9 @@ class PaymentInteractionAddedMessageSchema(MessageSchema):
 
 class PaymentStatusInterfaceCodeSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentStatusInterfaceCodeSetMessagePayload`."
-    payment_id = marshmallow.fields.String(allow_none=True, data_key="paymentId")
+    payment_id = marshmallow.fields.String(allow_none=True, data_key="paymentId", attribute="paymentId")
     interface_code = marshmallow.fields.String(
-        allow_none=True, data_key="interfaceCode"
+        allow_none=True, data_key="interfaceCode", attribute="interfaceCode"
     )
 
     class Meta:
@@ -2162,9 +2219,9 @@ class PaymentStatusInterfaceCodeSetMessagePayloadSchema(MessagePayloadSchema):
 
 class PaymentStatusInterfaceCodeSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentStatusInterfaceCodeSetMessage`."
-    payment_id = marshmallow.fields.String(allow_none=True, data_key="paymentId")
+    payment_id = marshmallow.fields.String(allow_none=True, data_key="paymentId", attribute="paymentId")
     interface_code = marshmallow.fields.String(
-        allow_none=True, data_key="interfaceCode"
+        allow_none=True, data_key="interfaceCode", attribute="interfaceCode"
     )
 
     class Meta:
@@ -2246,7 +2303,7 @@ class PaymentTransactionAddedMessageSchema(MessageSchema):
 class PaymentTransactionStateChangedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentTransactionStateChangedMessagePayload`."
     transaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="transactionId"
+        allow_none=True, data_key="transactionId", attribute="transactionId"
     )
     state = marshmallow_enum.EnumField(types.TransactionState, by_value=True)
 
@@ -2262,7 +2319,7 @@ class PaymentTransactionStateChangedMessagePayloadSchema(MessagePayloadSchema):
 class PaymentTransactionStateChangedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentTransactionStateChangedMessage`."
     transaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="transactionId"
+        allow_none=True, data_key="transactionId", attribute="transactionId"
     )
     state = marshmallow_enum.EnumField(types.TransactionState, by_value=True)
 
@@ -2281,6 +2338,7 @@ class ProductCreatedMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productProjection",
+        attribute="productProjection",
     )
 
     class Meta:
@@ -2299,6 +2357,7 @@ class ProductCreatedMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productProjection",
+        attribute="productProjection",
     )
 
     class Meta:
@@ -2319,12 +2378,14 @@ class ProductDeletedMessagePayloadSchema(MessagePayloadSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     current_projection = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductProjectionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="currentProjection",
+        attribute="currentProjection",
     )
 
     class Meta:
@@ -2346,12 +2407,14 @@ class ProductDeletedMessageSchema(MessageSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     current_projection = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductProjectionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="currentProjection",
+        attribute="currentProjection",
     )
 
     class Meta:
@@ -2364,7 +2427,7 @@ class ProductDeletedMessageSchema(MessageSchema):
 
 class ProductImageAddedMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductImageAddedMessagePayload`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     image = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.ImageSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2383,7 +2446,7 @@ class ProductImageAddedMessagePayloadSchema(MessagePayloadSchema):
 
 class ProductImageAddedMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductImageAddedMessage`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     image = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.ImageSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2407,6 +2470,7 @@ class ProductPriceDiscountsSetMessagePayloadSchema(MessagePayloadSchema):
         allow_none=True,
         many=True,
         data_key="updatedPrices",
+        attribute="updatedPrices",
     )
 
     class Meta:
@@ -2426,6 +2490,7 @@ class ProductPriceDiscountsSetMessageSchema(MessageSchema):
         allow_none=True,
         many=True,
         data_key="updatedPrices",
+        attribute="updatedPrices",
     )
 
     class Meta:
@@ -2438,12 +2503,12 @@ class ProductPriceDiscountsSetMessageSchema(MessageSchema):
 
 class ProductPriceExternalDiscountSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductPriceExternalDiscountSetMessagePayload`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     variant_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="variantKey"
+        allow_none=True, missing=None, data_key="variantKey", attribute="variantKey"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2463,12 +2528,12 @@ class ProductPriceExternalDiscountSetMessagePayloadSchema(MessagePayloadSchema):
 
 class ProductPriceExternalDiscountSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductPriceExternalDiscountSetMessage`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     variant_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="variantKey"
+        allow_none=True, missing=None, data_key="variantKey", attribute="variantKey"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
         unknown=marshmallow.EXCLUDE,
@@ -2495,12 +2560,14 @@ class ProductPublishedMessagePayloadSchema(MessagePayloadSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     product_projection = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductProjectionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productProjection",
+        attribute="productProjection",
     )
     scope = marshmallow_enum.EnumField(types.ProductPublishScope, by_value=True)
 
@@ -2523,12 +2590,14 @@ class ProductPublishedMessageSchema(MessageSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     product_projection = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductProjectionSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productProjection",
+        attribute="productProjection",
     )
     scope = marshmallow_enum.EnumField(types.ProductPublishScope, by_value=True)
 
@@ -2550,6 +2619,7 @@ class ProductRevertedStagedChangesMessagePayloadSchema(MessagePayloadSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
 
     class Meta:
@@ -2571,6 +2641,7 @@ class ProductRevertedStagedChangesMessageSchema(MessageSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
 
     class Meta:
@@ -2674,6 +2745,7 @@ class ProductVariantDeletedMessagePayloadSchema(MessagePayloadSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
@@ -2700,6 +2772,7 @@ class ProductVariantDeletedMessageSchema(MessageSchema):
         ),
         allow_none=True,
         data_key="removedImageUrls",
+        attribute="removedImageUrls",
     )
     variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
@@ -2751,13 +2824,13 @@ class ReviewCreatedMessageSchema(MessageSchema):
 class ReviewRatingSetMessagePayloadSchema(MessagePayloadSchema):
     "Marshmallow schema for :class:`commercetools.types.ReviewRatingSetMessagePayload`."
     old_rating = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="oldRating"
+        allow_none=True, missing=None, data_key="oldRating", attribute="oldRating"
     )
     new_rating = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="newRating"
+        allow_none=True, missing=None, data_key="newRating", attribute="newRating"
     )
     included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="includedInStatistics"
+        allow_none=True, data_key="includedInStatistics", attribute="includedInStatistics"
     )
     target = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
@@ -2803,13 +2876,13 @@ class ReviewRatingSetMessagePayloadSchema(MessagePayloadSchema):
 class ReviewRatingSetMessageSchema(MessageSchema):
     "Marshmallow schema for :class:`commercetools.types.ReviewRatingSetMessage`."
     old_rating = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="oldRating"
+        allow_none=True, missing=None, data_key="oldRating", attribute="oldRating"
     )
     new_rating = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="newRating"
+        allow_none=True, missing=None, data_key="newRating", attribute="newRating"
     )
     included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="includedInStatistics"
+        allow_none=True, data_key="includedInStatistics", attribute="includedInStatistics"
     )
     target = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
@@ -2858,18 +2931,20 @@ class ReviewStateTransitionMessagePayloadSchema(MessagePayloadSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="oldState",
+        attribute="oldState",
     )
     new_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="newState",
+        attribute="newState",
     )
     old_included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="oldIncludedInStatistics"
+        allow_none=True, data_key="oldIncludedInStatistics", attribute="oldIncludedInStatistics"
     )
     new_included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="newIncludedInStatistics"
+        allow_none=True, data_key="newIncludedInStatistics", attribute="newIncludedInStatistics"
     )
     target = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
@@ -2919,18 +2994,20 @@ class ReviewStateTransitionMessageSchema(MessageSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="oldState",
+        attribute="oldState",
     )
     new_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="newState",
+        attribute="newState",
     )
     old_included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="oldIncludedInStatistics"
+        allow_none=True, data_key="oldIncludedInStatistics", attribute="oldIncludedInStatistics"
     )
     new_included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="newIncludedInStatistics"
+        allow_none=True, data_key="newIncludedInStatistics", attribute="newIncludedInStatistics"
     )
     target = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),

--- a/src/commercetools/schemas/_order.py
+++ b/src/commercetools/schemas/_order.py
@@ -100,7 +100,7 @@ class DeliveryItemSchema(marshmallow.Schema):
 class DeliverySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.Delivery`."
     id = marshmallow.fields.String(allow_none=True)
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -141,6 +141,7 @@ class DiscountedLineItemPriceDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="includedDiscounts",
+        attribute="includedDiscounts",
     )
 
     class Meta:
@@ -171,7 +172,7 @@ class ItemStateSchema(marshmallow.Schema):
 class LineItemImportDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.LineItemImportDraft`."
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     name = LocalizedStringField(allow_none=True)
     variant = marshmallow.fields.Nested(
@@ -198,6 +199,7 @@ class LineItemImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -205,6 +207,7 @@ class LineItemImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxRateSchema",
@@ -212,6 +215,7 @@ class LineItemImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxRate",
+        attribute="taxRate",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -225,6 +229,7 @@ class LineItemImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -240,10 +245,10 @@ class OrderFromCartDraftSchema(marshmallow.Schema):
     id = marshmallow.fields.String(allow_none=True)
     version = marshmallow.fields.Integer(allow_none=True)
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, missing=None, data_key="paymentState"
+        types.PaymentState, by_value=True, missing=None, data_key="paymentState", attribute="paymentState"
     )
 
     class Meta:
@@ -257,13 +262,13 @@ class OrderFromCartDraftSchema(marshmallow.Schema):
 class OrderImportDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.OrderImportDraft`."
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
     customer_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerEmail"
+        allow_none=True, missing=None, data_key="customerEmail", attribute="customerEmail"
     )
     line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.LineItemImportDraftSchema",
@@ -272,6 +277,7 @@ class OrderImportDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="lineItems",
+        attribute="lineItems",
     )
     custom_line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.CustomLineItemDraftSchema",
@@ -280,12 +286,14 @@ class OrderImportDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="customLineItems",
+        attribute="customLineItems",
     )
     total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedPriceSchema",
@@ -293,6 +301,7 @@ class OrderImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     shipping_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -300,6 +309,7 @@ class OrderImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingAddress",
+        attribute="shippingAddress",
     )
     billing_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -307,6 +317,7 @@ class OrderImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="billingAddress",
+        attribute="billingAddress",
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupResourceIdentifierSchema",
@@ -314,16 +325,17 @@ class OrderImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     country = marshmallow.fields.String(allow_none=True, missing=None)
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, missing=None, data_key="orderState"
+        types.OrderState, by_value=True, missing=None, data_key="orderState", attribute="orderState"
     )
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState"
+        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState", attribute="shipmentState"
     )
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, missing=None, data_key="paymentState"
+        types.PaymentState, by_value=True, missing=None, data_key="paymentState", attribute="paymentState"
     )
     shipping_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ShippingInfoImportDraftSchema",
@@ -331,9 +343,10 @@ class OrderImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingInfo",
+        attribute="shippingInfo",
     )
     completed_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="completedAt"
+        allow_none=True, missing=None, data_key="completedAt", attribute="completedAt"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -342,10 +355,10 @@ class OrderImportDraftSchema(marshmallow.Schema):
         missing=None,
     )
     inventory_mode = marshmallow_enum.EnumField(
-        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode"
+        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode", attribute="inventoryMode"
     )
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
     item_shipping_addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -354,6 +367,7 @@ class OrderImportDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="itemShippingAddresses",
+        attribute="itemShippingAddresses",
     )
 
     class Meta:
@@ -417,19 +431,19 @@ class OrderResourceIdentifierSchema(ResourceIdentifierSchema):
 class OrderSchema(LoggedResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.Order`."
     completed_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="completedAt"
+        allow_none=True, missing=None, data_key="completedAt", attribute="completedAt"
     )
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
     customer_email = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerEmail"
+        allow_none=True, missing=None, data_key="customerEmail", attribute="customerEmail"
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     store = marshmallow.fields.Nested(
         nested="commercetools.schemas._store.StoreKeyReferenceSchema",
@@ -443,6 +457,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="lineItems",
+        attribute="lineItems",
     )
     custom_line_items = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.CustomLineItemSchema",
@@ -450,12 +465,14 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="customLineItems",
+        attribute="customLineItems",
     )
     total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedPriceSchema",
@@ -463,6 +480,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     shipping_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -470,6 +488,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingAddress",
+        attribute="shippingAddress",
     )
     billing_address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -477,12 +496,13 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="billingAddress",
+        attribute="billingAddress",
     )
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, missing=None, data_key="taxMode"
+        types.TaxMode, by_value=True, missing=None, data_key="taxMode", attribute="taxMode"
     )
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, missing=None, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
     customer_group = marshmallow.fields.Nested(
         nested="commercetools.schemas._customer_group.CustomerGroupReferenceSchema",
@@ -490,10 +510,11 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
     country = marshmallow.fields.String(allow_none=True, missing=None)
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="orderState"
+        types.OrderState, by_value=True, data_key="orderState", attribute="orderState"
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
@@ -502,10 +523,10 @@ class OrderSchema(LoggedResourceSchema):
         missing=None,
     )
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState"
+        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState", attribute="shipmentState"
     )
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, missing=None, data_key="paymentState"
+        types.PaymentState, by_value=True, missing=None, data_key="paymentState", attribute="paymentState"
     )
     shipping_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ShippingInfoSchema",
@@ -513,6 +534,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingInfo",
+        attribute="shippingInfo",
     )
     sync_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.SyncInfoSchema",
@@ -520,6 +542,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="syncInfo",
+        attribute="syncInfo",
     )
     return_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ReturnInfoSchema",
@@ -528,6 +551,7 @@ class OrderSchema(LoggedResourceSchema):
         many=True,
         missing=None,
         data_key="returnInfo",
+        attribute="returnInfo",
     )
     discount_codes = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.DiscountCodeInfoSchema",
@@ -536,9 +560,10 @@ class OrderSchema(LoggedResourceSchema):
         many=True,
         missing=None,
         data_key="discountCodes",
+        attribute="discountCodes",
     )
     last_message_sequence_number = marshmallow.fields.Integer(
-        allow_none=True, data_key="lastMessageSequenceNumber"
+        allow_none=True, data_key="lastMessageSequenceNumber", attribute="lastMessageSequenceNumber"
     )
     cart = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.CartReferenceSchema",
@@ -558,10 +583,11 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="paymentInfo",
+        attribute="paymentInfo",
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     inventory_mode = marshmallow_enum.EnumField(
-        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode"
+        types.InventoryMode, by_value=True, missing=None, data_key="inventoryMode", attribute="inventoryMode"
     )
     origin = marshmallow_enum.EnumField(types.CartOrigin, by_value=True)
     tax_calculation_mode = marshmallow_enum.EnumField(
@@ -569,6 +595,7 @@ class OrderSchema(LoggedResourceSchema):
         by_value=True,
         missing=None,
         data_key="taxCalculationMode",
+        attribute="taxCalculationMode",
     )
     shipping_rate_input = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -580,6 +607,7 @@ class OrderSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
     item_shipping_addresses = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
@@ -588,6 +616,7 @@ class OrderSchema(LoggedResourceSchema):
         many=True,
         missing=None,
         data_key="itemShippingAddresses",
+        attribute="itemShippingAddresses",
     )
 
     class Meta:
@@ -687,6 +716,7 @@ class ParcelDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -707,16 +737,16 @@ class ParcelDraftSchema(marshmallow.Schema):
 class ParcelMeasurementsSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ParcelMeasurements`."
     height_in_millimeter = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="heightInMillimeter"
+        allow_none=True, missing=None, data_key="heightInMillimeter", attribute="heightInMillimeter"
     )
     length_in_millimeter = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="lengthInMillimeter"
+        allow_none=True, missing=None, data_key="lengthInMillimeter", attribute="lengthInMillimeter"
     )
     width_in_millimeter = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="widthInMillimeter"
+        allow_none=True, missing=None, data_key="widthInMillimeter", attribute="widthInMillimeter"
     )
     weight_in_gram = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="weightInGram"
+        allow_none=True, missing=None, data_key="weightInGram", attribute="weightInGram"
     )
 
     class Meta:
@@ -730,7 +760,7 @@ class ParcelMeasurementsSchema(marshmallow.Schema):
 class ParcelSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.Parcel`."
     id = marshmallow.fields.String(allow_none=True)
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -743,6 +773,7 @@ class ParcelSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -825,10 +856,10 @@ class ReturnInfoSchema(marshmallow.Schema):
         )
     )
     return_tracking_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="returnTrackingId"
+        allow_none=True, missing=None, data_key="returnTrackingId", attribute="returnTrackingId"
     )
     return_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="returnDate"
+        allow_none=True, missing=None, data_key="returnDate", attribute="returnDate"
     )
 
     class Meta:
@@ -843,14 +874,14 @@ class ReturnItemDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ReturnItemDraft`."
     quantity = marshmallow.fields.Integer(allow_none=True)
     line_item_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="lineItemId"
+        allow_none=True, missing=None, data_key="lineItemId", attribute="lineItemId"
     )
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customLineItemId"
+        allow_none=True, missing=None, data_key="customLineItemId", attribute="customLineItemId"
     )
     comment = marshmallow.fields.String(allow_none=True, missing=None)
     shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="shipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
 
     class Meta:
@@ -868,15 +899,15 @@ class ReturnItemSchema(marshmallow.Schema):
     type = marshmallow.fields.String(allow_none=True)
     comment = marshmallow.fields.String(allow_none=True, missing=None)
     shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="shipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
     payment_state = marshmallow_enum.EnumField(
-        types.ReturnPaymentState, by_value=True, data_key="paymentState"
+        types.ReturnPaymentState, by_value=True, data_key="paymentState", attribute="paymentState"
     )
     last_modified_at = marshmallow.fields.DateTime(
-        allow_none=True, data_key="lastModifiedAt"
+        allow_none=True, data_key="lastModifiedAt", attribute="lastModifiedAt"
     )
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -890,7 +921,7 @@ class ReturnItemSchema(marshmallow.Schema):
 class ShippingInfoImportDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ShippingInfoImportDraft`."
     shipping_method_name = marshmallow.fields.String(
-        allow_none=True, data_key="shippingMethodName"
+        allow_none=True, data_key="shippingMethodName", attribute="shippingMethodName"
     )
     price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -902,6 +933,7 @@ class ShippingInfoImportDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxRateSchema",
@@ -909,6 +941,7 @@ class ShippingInfoImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxRate",
+        attribute="taxRate",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryResourceIdentifierSchema",
@@ -916,6 +949,7 @@ class ShippingInfoImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     shipping_method = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingMethodResourceIdentifierSchema",
@@ -923,6 +957,7 @@ class ShippingInfoImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     deliveries = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliverySchema",
@@ -937,12 +972,14 @@ class ShippingInfoImportDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="discountedPrice",
+        attribute="discountedPrice",
     )
     shipping_method_state = marshmallow_enum.EnumField(
         types.ShippingMethodState,
         by_value=True,
         missing=None,
         data_key="shippingMethodState",
+        attribute="shippingMethodState",
     )
 
     class Meta:
@@ -974,9 +1011,9 @@ class SyncInfoSchema(marshmallow.Schema):
         allow_none=True,
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
-    synced_at = marshmallow.fields.DateTime(allow_none=True, data_key="syncedAt")
+    synced_at = marshmallow.fields.DateTime(allow_none=True, data_key="syncedAt", attribute="syncedAt")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -993,12 +1030,14 @@ class TaxedItemPriceDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalNet",
+        attribute="totalNet",
     )
     total_gross = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalGross",
+        attribute="totalGross",
     )
 
     class Meta:
@@ -1012,15 +1051,15 @@ class TaxedItemPriceDraftSchema(marshmallow.Schema):
 class TrackingDataSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.TrackingData`."
     tracking_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="trackingId"
+        allow_none=True, missing=None, data_key="trackingId", attribute="trackingId"
     )
     carrier = marshmallow.fields.String(allow_none=True, missing=None)
     provider = marshmallow.fields.String(allow_none=True, missing=None)
     provider_transaction = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="providerTransaction"
+        allow_none=True, missing=None, data_key="providerTransaction", attribute="providerTransaction"
     )
     is_return = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isReturn"
+        allow_none=True, missing=None, data_key="isReturn", attribute="isReturn"
     )
 
     class Meta:
@@ -1034,7 +1073,7 @@ class TrackingDataSchema(marshmallow.Schema):
 class CustomLineItemReturnItemSchema(ReturnItemSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomLineItemReturnItem`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
 
     class Meta:
@@ -1048,7 +1087,7 @@ class CustomLineItemReturnItemSchema(ReturnItemSchema):
 
 class LineItemReturnItemSchema(ReturnItemSchema):
     "Marshmallow schema for :class:`commercetools.types.LineItemReturnItem`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1110,7 +1149,7 @@ class OrderAddItemShippingAddressActionSchema(OrderUpdateActionSchema):
 
 class OrderAddParcelToDeliveryActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderAddParcelToDeliveryAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1123,6 +1162,7 @@ class OrderAddParcelToDeliveryActionSchema(OrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -1161,7 +1201,7 @@ class OrderAddPaymentActionSchema(OrderUpdateActionSchema):
 class OrderAddReturnInfoActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderAddReturnInfoAction`."
     return_tracking_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="returnTrackingId"
+        allow_none=True, missing=None, data_key="returnTrackingId", attribute="returnTrackingId"
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ReturnItemDraftSchema",
@@ -1170,7 +1210,7 @@ class OrderAddReturnInfoActionSchema(OrderUpdateActionSchema):
         many=True,
     )
     return_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="returnDate"
+        allow_none=True, missing=None, data_key="returnDate", attribute="returnDate"
     )
 
     class Meta:
@@ -1185,7 +1225,7 @@ class OrderAddReturnInfoActionSchema(OrderUpdateActionSchema):
 class OrderChangeOrderStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderChangeOrderStateAction`."
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="orderState"
+        types.OrderState, by_value=True, data_key="orderState", attribute="orderState"
     )
 
     class Meta:
@@ -1200,7 +1240,7 @@ class OrderChangeOrderStateActionSchema(OrderUpdateActionSchema):
 class OrderChangePaymentStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderChangePaymentStateAction`."
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, missing=None, data_key="paymentState"
+        types.PaymentState, by_value=True, missing=None, data_key="paymentState", attribute="paymentState"
     )
 
     class Meta:
@@ -1215,7 +1255,7 @@ class OrderChangePaymentStateActionSchema(OrderUpdateActionSchema):
 class OrderChangeShipmentStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderChangeShipmentStateAction`."
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState"
+        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState", attribute="shipmentState"
     )
 
     class Meta:
@@ -1230,7 +1270,7 @@ class OrderChangeShipmentStateActionSchema(OrderUpdateActionSchema):
 class OrderImportCustomLineItemStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderImportCustomLineItemStateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ItemStateSchema",
@@ -1250,7 +1290,7 @@ class OrderImportCustomLineItemStateActionSchema(OrderUpdateActionSchema):
 
 class OrderImportLineItemStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderImportLineItemStateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ItemStateSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1269,7 +1309,7 @@ class OrderImportLineItemStateActionSchema(OrderUpdateActionSchema):
 
 class OrderRemoveDeliveryActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderRemoveDeliveryAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1282,7 +1322,7 @@ class OrderRemoveDeliveryActionSchema(OrderUpdateActionSchema):
 
 class OrderRemoveItemShippingAddressActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderRemoveItemShippingAddressAction`."
-    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey")
+    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey", attribute="addressKey")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1295,7 +1335,7 @@ class OrderRemoveItemShippingAddressActionSchema(OrderUpdateActionSchema):
 
 class OrderRemoveParcelFromDeliveryActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderRemoveParcelFromDeliveryAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1358,7 +1398,7 @@ class OrderSetCustomFieldActionSchema(OrderUpdateActionSchema):
 class OrderSetCustomLineItemCustomFieldActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetCustomLineItemCustomFieldAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -1375,7 +1415,7 @@ class OrderSetCustomLineItemCustomFieldActionSchema(OrderUpdateActionSchema):
 class OrderSetCustomLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetCustomLineItemCustomTypeAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -1397,7 +1437,7 @@ class OrderSetCustomLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
 class OrderSetCustomLineItemShippingDetailsActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetCustomLineItemShippingDetailsAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1405,6 +1445,7 @@ class OrderSetCustomLineItemShippingDetailsActionSchema(OrderUpdateActionSchema)
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1451,7 +1492,7 @@ class OrderSetCustomerEmailActionSchema(OrderUpdateActionSchema):
 class OrderSetCustomerIdActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetCustomerIdAction`."
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
 
     class Meta:
@@ -1465,7 +1506,7 @@ class OrderSetCustomerIdActionSchema(OrderUpdateActionSchema):
 
 class OrderSetDeliveryAddressActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetDeliveryAddressAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1484,7 +1525,7 @@ class OrderSetDeliveryAddressActionSchema(OrderUpdateActionSchema):
 
 class OrderSetDeliveryItemsActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetDeliveryItemsAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1503,7 +1544,7 @@ class OrderSetDeliveryItemsActionSchema(OrderUpdateActionSchema):
 
 class OrderSetLineItemCustomFieldActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetLineItemCustomFieldAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
 
@@ -1518,7 +1559,7 @@ class OrderSetLineItemCustomFieldActionSchema(OrderUpdateActionSchema):
 
 class OrderSetLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetLineItemCustomTypeAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1538,13 +1579,14 @@ class OrderSetLineItemCustomTypeActionSchema(OrderUpdateActionSchema):
 
 class OrderSetLineItemShippingDetailsActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetLineItemShippingDetailsAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1572,7 +1614,7 @@ class OrderSetLocaleActionSchema(OrderUpdateActionSchema):
 class OrderSetOrderNumberActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetOrderNumberAction`."
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
 
     class Meta:
@@ -1586,7 +1628,7 @@ class OrderSetOrderNumberActionSchema(OrderUpdateActionSchema):
 
 class OrderSetParcelItemsActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetParcelItemsAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1605,7 +1647,7 @@ class OrderSetParcelItemsActionSchema(OrderUpdateActionSchema):
 
 class OrderSetParcelMeasurementsActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetParcelMeasurementsAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1624,13 +1666,14 @@ class OrderSetParcelMeasurementsActionSchema(OrderUpdateActionSchema):
 
 class OrderSetParcelTrackingDataActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetParcelTrackingDataAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     tracking_data = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.TrackingDataSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
 
     class Meta:
@@ -1644,9 +1687,9 @@ class OrderSetParcelTrackingDataActionSchema(OrderUpdateActionSchema):
 
 class OrderSetReturnPaymentStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetReturnPaymentStateAction`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     payment_state = marshmallow_enum.EnumField(
-        types.ReturnPaymentState, by_value=True, data_key="paymentState"
+        types.ReturnPaymentState, by_value=True, data_key="paymentState", attribute="paymentState"
     )
 
     class Meta:
@@ -1660,9 +1703,9 @@ class OrderSetReturnPaymentStateActionSchema(OrderUpdateActionSchema):
 
 class OrderSetReturnShipmentStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderSetReturnShipmentStateAction`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="shipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
 
     class Meta:
@@ -1695,7 +1738,7 @@ class OrderSetShippingAddressActionSchema(OrderUpdateActionSchema):
 class OrderTransitionCustomLineItemStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderTransitionCustomLineItemStateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -1703,15 +1746,17 @@ class OrderTransitionCustomLineItemStateActionSchema(OrderUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
     actual_transition_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="actualTransitionDate"
+        allow_none=True, missing=None, data_key="actualTransitionDate", attribute="actualTransitionDate"
     )
 
     class Meta:
@@ -1725,22 +1770,24 @@ class OrderTransitionCustomLineItemStateActionSchema(OrderUpdateActionSchema):
 
 class OrderTransitionLineItemStateActionSchema(OrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderTransitionLineItemStateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
     actual_transition_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="actualTransitionDate"
+        allow_none=True, missing=None, data_key="actualTransitionDate", attribute="actualTransitionDate"
     )
 
     class Meta:
@@ -1795,10 +1842,10 @@ class OrderUpdateSyncInfoActionSchema(OrderUpdateActionSchema):
         allow_none=True,
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     synced_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="syncedAt"
+        allow_none=True, missing=None, data_key="syncedAt", attribute="syncedAt"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_order_edit.py
+++ b/src/commercetools/schemas/_order_edit.py
@@ -109,9 +109,9 @@ __all__ = [
 
 class OrderEditApplySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.OrderEditApply`."
-    edit_version = marshmallow.fields.Integer(allow_none=True, data_key="editVersion")
+    edit_version = marshmallow.fields.Integer(allow_none=True, data_key="editVersion", attribute="editVersion")
     resource_version = marshmallow.fields.Integer(
-        allow_none=True, data_key="resourceVersion"
+        allow_none=True, data_key="resourceVersion", attribute="resourceVersion"
     )
 
     class Meta:
@@ -209,6 +209,7 @@ class OrderEditDraftSchema(marshmallow.Schema):
         ),
         missing=None,
         data_key="stagedActions",
+        attribute="stagedActions",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -217,7 +218,7 @@ class OrderEditDraftSchema(marshmallow.Schema):
         missing=None,
     )
     comment = marshmallow.fields.String(allow_none=True, missing=None)
-    dry_run = marshmallow.fields.Bool(allow_none=True, missing=None, data_key="dryRun")
+    dry_run = marshmallow.fields.Bool(allow_none=True, missing=None, data_key="dryRun", attribute="dryRun")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -292,9 +293,9 @@ class OrderEditResultSchema(marshmallow.Schema):
 
 class OrderEditSchema(LoggedResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderEdit`."
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     last_modified_at = marshmallow.fields.DateTime(
-        allow_none=True, data_key="lastModifiedAt"
+        allow_none=True, data_key="lastModifiedAt", attribute="lastModifiedAt"
     )
     key = marshmallow.fields.String(allow_none=True, missing=None)
     resource = marshmallow.fields.Nested(
@@ -380,6 +381,7 @@ class OrderEditSchema(LoggedResourceSchema):
             allow_none=True,
         ),
         data_key="stagedActions",
+        attribute="stagedActions",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -439,7 +441,7 @@ class OrderEditUpdateSchema(marshmallow.Schema):
             allow_none=True,
         )
     )
-    dry_run = marshmallow.fields.Bool(allow_none=True, data_key="dryRun")
+    dry_run = marshmallow.fields.Bool(allow_none=True, data_key="dryRun", attribute="dryRun")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -456,6 +458,7 @@ class OrderExcerptSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="totalPrice",
+        attribute="totalPrice",
     )
     taxed_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxedPriceSchema",
@@ -463,6 +466,7 @@ class OrderExcerptSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxedPrice",
+        attribute="taxedPrice",
     )
     version = marshmallow.fields.Integer(allow_none=True)
 
@@ -490,6 +494,7 @@ class StagedOrderAddCustomLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -503,6 +508,7 @@ class StagedOrderAddCustomLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -590,6 +596,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -597,12 +604,13 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
@@ -612,6 +620,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -619,6 +628,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -626,6 +636,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -633,6 +644,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -646,7 +658,7 @@ class StagedOrderAddLineItemActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderAddParcelToDeliveryActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderAddParcelToDeliveryAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -659,6 +671,7 @@ class StagedOrderAddParcelToDeliveryActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
@@ -697,7 +710,7 @@ class StagedOrderAddPaymentActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderAddReturnInfoActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderAddReturnInfoAction`."
     return_tracking_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="returnTrackingId"
+        allow_none=True, missing=None, data_key="returnTrackingId", attribute="returnTrackingId"
     )
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ReturnItemDraftSchema",
@@ -706,7 +719,7 @@ class StagedOrderAddReturnInfoActionSchema(StagedOrderUpdateActionSchema):
         many=True,
     )
     return_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="returnDate"
+        allow_none=True, missing=None, data_key="returnDate", attribute="returnDate"
     )
 
     class Meta:
@@ -725,6 +738,7 @@ class StagedOrderAddShoppingListActionSchema(StagedOrderUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shoppingList",
+        attribute="shoppingList",
     )
     supply_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -732,6 +746,7 @@ class StagedOrderAddShoppingListActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="supplyChannel",
+        attribute="supplyChannel",
     )
     distribution_channel = marshmallow.fields.Nested(
         nested="commercetools.schemas._channel.ChannelResourceIdentifierSchema",
@@ -739,6 +754,7 @@ class StagedOrderAddShoppingListActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="distributionChannel",
+        attribute="distributionChannel",
     )
 
     class Meta:
@@ -753,7 +769,7 @@ class StagedOrderAddShoppingListActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderChangeCustomLineItemMoneyActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeCustomLineItemMoneyAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     money = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -775,7 +791,7 @@ class StagedOrderChangeCustomLineItemQuantityActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeCustomLineItemQuantityAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
 
@@ -790,7 +806,7 @@ class StagedOrderChangeCustomLineItemQuantityActionSchema(
 
 class StagedOrderChangeLineItemQuantityActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeLineItemQuantityAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True)
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -798,6 +814,7 @@ class StagedOrderChangeLineItemQuantityActionSchema(StagedOrderUpdateActionSchem
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -805,6 +822,7 @@ class StagedOrderChangeLineItemQuantityActionSchema(StagedOrderUpdateActionSchem
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
 
     class Meta:
@@ -819,7 +837,7 @@ class StagedOrderChangeLineItemQuantityActionSchema(StagedOrderUpdateActionSchem
 class StagedOrderChangeOrderStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeOrderStateAction`."
     order_state = marshmallow_enum.EnumField(
-        types.OrderState, by_value=True, data_key="orderState"
+        types.OrderState, by_value=True, data_key="orderState", attribute="orderState"
     )
 
     class Meta:
@@ -834,7 +852,7 @@ class StagedOrderChangeOrderStateActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderChangePaymentStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangePaymentStateAction`."
     payment_state = marshmallow_enum.EnumField(
-        types.PaymentState, by_value=True, missing=None, data_key="paymentState"
+        types.PaymentState, by_value=True, missing=None, data_key="paymentState", attribute="paymentState"
     )
 
     class Meta:
@@ -849,7 +867,7 @@ class StagedOrderChangePaymentStateActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderChangeShipmentStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeShipmentStateAction`."
     shipment_state = marshmallow_enum.EnumField(
-        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState"
+        types.ShipmentState, by_value=True, missing=None, data_key="shipmentState", attribute="shipmentState"
     )
 
     class Meta:
@@ -864,7 +882,7 @@ class StagedOrderChangeShipmentStateActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderChangeTaxCalculationModeActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeTaxCalculationModeAction`."
     tax_calculation_mode = marshmallow_enum.EnumField(
-        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode"
+        types.TaxCalculationMode, by_value=True, data_key="taxCalculationMode", attribute="taxCalculationMode"
     )
 
     class Meta:
@@ -879,7 +897,7 @@ class StagedOrderChangeTaxCalculationModeActionSchema(StagedOrderUpdateActionSch
 class StagedOrderChangeTaxModeActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeTaxModeAction`."
     tax_mode = marshmallow_enum.EnumField(
-        types.TaxMode, by_value=True, data_key="taxMode"
+        types.TaxMode, by_value=True, data_key="taxMode", attribute="taxMode"
     )
 
     class Meta:
@@ -894,7 +912,7 @@ class StagedOrderChangeTaxModeActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderChangeTaxRoundingModeActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderChangeTaxRoundingModeAction`."
     tax_rounding_mode = marshmallow_enum.EnumField(
-        types.RoundingMode, by_value=True, data_key="taxRoundingMode"
+        types.RoundingMode, by_value=True, data_key="taxRoundingMode", attribute="taxRoundingMode"
     )
 
     class Meta:
@@ -909,7 +927,7 @@ class StagedOrderChangeTaxRoundingModeActionSchema(StagedOrderUpdateActionSchema
 class StagedOrderImportCustomLineItemStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderImportCustomLineItemStateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ItemStateSchema",
@@ -929,7 +947,7 @@ class StagedOrderImportCustomLineItemStateActionSchema(StagedOrderUpdateActionSc
 
 class StagedOrderImportLineItemStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderImportLineItemStateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ItemStateSchema",
         unknown=marshmallow.EXCLUDE,
@@ -949,7 +967,7 @@ class StagedOrderImportLineItemStateActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderRemoveCustomLineItemActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderRemoveCustomLineItemAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
 
     class Meta:
@@ -963,7 +981,7 @@ class StagedOrderRemoveCustomLineItemActionSchema(StagedOrderUpdateActionSchema)
 
 class StagedOrderRemoveDeliveryActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderRemoveDeliveryAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -981,6 +999,7 @@ class StagedOrderRemoveDiscountCodeActionSchema(StagedOrderUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="discountCode",
+        attribute="discountCode",
     )
 
     class Meta:
@@ -994,7 +1013,7 @@ class StagedOrderRemoveDiscountCodeActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderRemoveItemShippingAddressActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderRemoveItemShippingAddressAction`."
-    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey")
+    address_key = marshmallow.fields.String(allow_none=True, data_key="addressKey", attribute="addressKey")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1007,7 +1026,7 @@ class StagedOrderRemoveItemShippingAddressActionSchema(StagedOrderUpdateActionSc
 
 class StagedOrderRemoveLineItemActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderRemoveLineItemAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -1015,6 +1034,7 @@ class StagedOrderRemoveLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
@@ -1022,6 +1042,7 @@ class StagedOrderRemoveLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
     shipping_details_to_remove = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1029,6 +1050,7 @@ class StagedOrderRemoveLineItemActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingDetailsToRemove",
+        attribute="shippingDetailsToRemove",
     )
 
     class Meta:
@@ -1042,7 +1064,7 @@ class StagedOrderRemoveLineItemActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderRemoveParcelFromDeliveryActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderRemoveParcelFromDeliveryAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1131,7 +1153,7 @@ class StagedOrderSetCustomLineItemCustomFieldActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomLineItemCustomFieldAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -1148,7 +1170,7 @@ class StagedOrderSetCustomLineItemCustomFieldActionSchema(
 class StagedOrderSetCustomLineItemCustomTypeActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomLineItemCustomTypeAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -1172,7 +1194,7 @@ class StagedOrderSetCustomLineItemShippingDetailsActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomLineItemShippingDetailsAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
@@ -1180,6 +1202,7 @@ class StagedOrderSetCustomLineItemShippingDetailsActionSchema(
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1194,7 +1217,7 @@ class StagedOrderSetCustomLineItemShippingDetailsActionSchema(
 class StagedOrderSetCustomLineItemTaxAmountActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomLineItemTaxAmountAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     external_tax_amount = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxAmountDraftSchema",
@@ -1202,6 +1225,7 @@ class StagedOrderSetCustomLineItemTaxAmountActionSchema(StagedOrderUpdateActionS
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -1216,7 +1240,7 @@ class StagedOrderSetCustomLineItemTaxAmountActionSchema(StagedOrderUpdateActionS
 class StagedOrderSetCustomLineItemTaxRateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomLineItemTaxRateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1224,6 +1248,7 @@ class StagedOrderSetCustomLineItemTaxRateActionSchema(StagedOrderUpdateActionSch
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1238,13 +1263,14 @@ class StagedOrderSetCustomLineItemTaxRateActionSchema(StagedOrderUpdateActionSch
 class StagedOrderSetCustomShippingMethodActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomShippingMethodAction`."
     shipping_method_name = marshmallow.fields.String(
-        allow_none=True, data_key="shippingMethodName"
+        allow_none=True, data_key="shippingMethodName", attribute="shippingMethodName"
     )
     shipping_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryResourceIdentifierSchema",
@@ -1252,6 +1278,7 @@ class StagedOrderSetCustomShippingMethodActionSchema(StagedOrderUpdateActionSche
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1259,6 +1286,7 @@ class StagedOrderSetCustomShippingMethodActionSchema(StagedOrderUpdateActionSche
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1310,6 +1338,7 @@ class StagedOrderSetCustomerGroupActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="customerGroup",
+        attribute="customerGroup",
     )
 
     class Meta:
@@ -1324,7 +1353,7 @@ class StagedOrderSetCustomerGroupActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderSetCustomerIdActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetCustomerIdAction`."
     customer_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="customerId"
+        allow_none=True, missing=None, data_key="customerId", attribute="customerId"
     )
 
     class Meta:
@@ -1338,7 +1367,7 @@ class StagedOrderSetCustomerIdActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetDeliveryAddressActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetDeliveryAddressAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     address = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AddressSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1357,7 +1386,7 @@ class StagedOrderSetDeliveryAddressActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetDeliveryItemsActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetDeliveryItemsAction`."
-    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId")
+    delivery_id = marshmallow.fields.String(allow_none=True, data_key="deliveryId", attribute="deliveryId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1376,7 +1405,7 @@ class StagedOrderSetDeliveryItemsActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetLineItemCustomFieldActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemCustomFieldAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
 
@@ -1391,7 +1420,7 @@ class StagedOrderSetLineItemCustomFieldActionSchema(StagedOrderUpdateActionSchem
 
 class StagedOrderSetLineItemCustomTypeActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemCustomTypeAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1411,13 +1440,14 @@ class StagedOrderSetLineItemCustomTypeActionSchema(StagedOrderUpdateActionSchema
 
 class StagedOrderSetLineItemPriceActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemPriceAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalPrice",
+        attribute="externalPrice",
     )
 
     class Meta:
@@ -1431,13 +1461,14 @@ class StagedOrderSetLineItemPriceActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetLineItemShippingDetailsActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemShippingDetailsAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     shipping_details = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ItemShippingDetailsDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="shippingDetails",
+        attribute="shippingDetails",
     )
 
     class Meta:
@@ -1451,13 +1482,14 @@ class StagedOrderSetLineItemShippingDetailsActionSchema(StagedOrderUpdateActionS
 
 class StagedOrderSetLineItemTaxAmountActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemTaxAmountAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_tax_amount = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxAmountDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -1471,13 +1503,14 @@ class StagedOrderSetLineItemTaxAmountActionSchema(StagedOrderUpdateActionSchema)
 
 class StagedOrderSetLineItemTaxRateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemTaxRateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1491,13 +1524,14 @@ class StagedOrderSetLineItemTaxRateActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetLineItemTotalPriceActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetLineItemTotalPriceAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     external_total_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalLineItemTotalPriceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="externalTotalPrice",
+        attribute="externalTotalPrice",
     )
 
     class Meta:
@@ -1525,7 +1559,7 @@ class StagedOrderSetLocaleActionSchema(StagedOrderUpdateActionSchema):
 class StagedOrderSetOrderNumberActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetOrderNumberAction`."
     order_number = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderNumber"
+        allow_none=True, missing=None, data_key="orderNumber", attribute="orderNumber"
     )
 
     class Meta:
@@ -1544,6 +1578,7 @@ class StagedOrderSetOrderTotalTaxActionSchema(StagedOrderUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="externalTotalGross",
+        attribute="externalTotalGross",
     )
     external_tax_portions = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.TaxPortionSchema",
@@ -1552,6 +1587,7 @@ class StagedOrderSetOrderTotalTaxActionSchema(StagedOrderUpdateActionSchema):
         many=True,
         missing=None,
         data_key="externalTaxPortions",
+        attribute="externalTaxPortions",
     )
 
     class Meta:
@@ -1565,7 +1601,7 @@ class StagedOrderSetOrderTotalTaxActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetParcelItemsActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetParcelItemsAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     items = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.DeliveryItemSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1584,7 +1620,7 @@ class StagedOrderSetParcelItemsActionSchema(StagedOrderUpdateActionSchema):
 
 class StagedOrderSetParcelMeasurementsActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetParcelMeasurementsAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     measurements = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.ParcelMeasurementsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1603,13 +1639,14 @@ class StagedOrderSetParcelMeasurementsActionSchema(StagedOrderUpdateActionSchema
 
 class StagedOrderSetParcelTrackingDataActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetParcelTrackingDataAction`."
-    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId")
+    parcel_id = marshmallow.fields.String(allow_none=True, data_key="parcelId", attribute="parcelId")
     tracking_data = marshmallow.fields.Nested(
         nested="commercetools.schemas._order.TrackingDataSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         missing=None,
         data_key="trackingData",
+        attribute="trackingData",
     )
 
     class Meta:
@@ -1623,9 +1660,9 @@ class StagedOrderSetParcelTrackingDataActionSchema(StagedOrderUpdateActionSchema
 
 class StagedOrderSetReturnPaymentStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetReturnPaymentStateAction`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     payment_state = marshmallow_enum.EnumField(
-        types.ReturnPaymentState, by_value=True, data_key="paymentState"
+        types.ReturnPaymentState, by_value=True, data_key="paymentState", attribute="paymentState"
     )
 
     class Meta:
@@ -1639,9 +1676,9 @@ class StagedOrderSetReturnPaymentStateActionSchema(StagedOrderUpdateActionSchema
 
 class StagedOrderSetReturnShipmentStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderSetReturnShipmentStateAction`."
-    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId")
+    return_item_id = marshmallow.fields.String(allow_none=True, data_key="returnItemId", attribute="returnItemId")
     shipment_state = marshmallow_enum.EnumField(
-        types.ReturnShipmentState, by_value=True, data_key="shipmentState"
+        types.ReturnShipmentState, by_value=True, data_key="shipmentState", attribute="shipmentState"
     )
 
     class Meta:
@@ -1681,13 +1718,14 @@ class StagedOrderSetShippingAddressAndCustomShippingMethodActionSchema(
         allow_none=True,
     )
     shipping_method_name = marshmallow.fields.String(
-        allow_none=True, data_key="shippingMethodName"
+        allow_none=True, data_key="shippingMethodName", attribute="shippingMethodName"
     )
     shipping_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ShippingRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryResourceIdentifierSchema",
@@ -1695,6 +1733,7 @@ class StagedOrderSetShippingAddressAndCustomShippingMethodActionSchema(
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1702,6 +1741,7 @@ class StagedOrderSetShippingAddressAndCustomShippingMethodActionSchema(
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1728,6 +1768,7 @@ class StagedOrderSetShippingAddressAndShippingMethodActionSchema(
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1735,6 +1776,7 @@ class StagedOrderSetShippingAddressAndShippingMethodActionSchema(
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1754,6 +1796,7 @@ class StagedOrderSetShippingMethodActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingMethod",
+        attribute="shippingMethod",
     )
     external_tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._cart.ExternalTaxRateDraftSchema",
@@ -1761,6 +1804,7 @@ class StagedOrderSetShippingMethodActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1780,6 +1824,7 @@ class StagedOrderSetShippingMethodTaxAmountActionSchema(StagedOrderUpdateActionS
         allow_none=True,
         missing=None,
         data_key="externalTaxAmount",
+        attribute="externalTaxAmount",
     )
 
     class Meta:
@@ -1799,6 +1844,7 @@ class StagedOrderSetShippingMethodTaxRateActionSchema(StagedOrderUpdateActionSch
         allow_none=True,
         missing=None,
         data_key="externalTaxRate",
+        attribute="externalTaxRate",
     )
 
     class Meta:
@@ -1822,6 +1868,7 @@ class StagedOrderSetShippingRateInputActionSchema(StagedOrderUpdateActionSchema)
         allow_none=True,
         missing=None,
         data_key="shippingRateInput",
+        attribute="shippingRateInput",
     )
 
     class Meta:
@@ -1838,7 +1885,7 @@ class StagedOrderTransitionCustomLineItemStateActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderTransitionCustomLineItemStateAction`."
     custom_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="customLineItemId"
+        allow_none=True, data_key="customLineItemId", attribute="customLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
@@ -1846,15 +1893,17 @@ class StagedOrderTransitionCustomLineItemStateActionSchema(
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
     actual_transition_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="actualTransitionDate"
+        allow_none=True, missing=None, data_key="actualTransitionDate", attribute="actualTransitionDate"
     )
 
     class Meta:
@@ -1868,22 +1917,24 @@ class StagedOrderTransitionCustomLineItemStateActionSchema(
 
 class StagedOrderTransitionLineItemStateActionSchema(StagedOrderUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.StagedOrderTransitionLineItemStateAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True)
     from_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fromState",
+        attribute="fromState",
     )
     to_state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="toState",
+        attribute="toState",
     )
     actual_transition_date = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="actualTransitionDate"
+        allow_none=True, missing=None, data_key="actualTransitionDate", attribute="actualTransitionDate"
     )
 
     class Meta:
@@ -1938,10 +1989,10 @@ class StagedOrderUpdateSyncInfoActionSchema(StagedOrderUpdateActionSchema):
         allow_none=True,
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     synced_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="syncedAt"
+        allow_none=True, missing=None, data_key="syncedAt", attribute="syncedAt"
     )
 
     class Meta:
@@ -2031,6 +2082,7 @@ class OrderEditAddStagedActionActionSchema(OrderEditUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="stagedAction",
+        attribute="stagedAction",
     )
 
     class Meta:
@@ -2044,18 +2096,20 @@ class OrderEditAddStagedActionActionSchema(OrderEditUpdateActionSchema):
 
 class OrderEditAppliedSchema(OrderEditResultSchema):
     "Marshmallow schema for :class:`commercetools.types.OrderEditApplied`."
-    applied_at = marshmallow.fields.DateTime(allow_none=True, data_key="appliedAt")
+    applied_at = marshmallow.fields.DateTime(allow_none=True, data_key="appliedAt", attribute="appliedAt")
     excerpt_before_edit = marshmallow.fields.Nested(
         nested="commercetools.schemas._order_edit.OrderExcerptSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="excerptBeforeEdit",
+        attribute="excerptBeforeEdit",
     )
     excerpt_after_edit = marshmallow.fields.Nested(
         nested="commercetools.schemas._order_edit.OrderExcerptSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="excerptAfterEdit",
+        attribute="excerptAfterEdit",
     )
 
     class Meta:
@@ -2212,6 +2266,7 @@ class OrderEditPreviewSuccessSchema(OrderEditResultSchema):
             allow_none=True,
         ),
         data_key="messagePayloads",
+        attribute="messagePayloads",
     )
 
     class Meta:
@@ -2362,6 +2417,7 @@ class OrderEditSetStagedActionsActionSchema(OrderEditUpdateActionSchema):
             allow_none=True,
         ),
         data_key="stagedActions",
+        attribute="stagedActions",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_payment.py
+++ b/src/commercetools/schemas/_payment.py
@@ -59,19 +59,20 @@ class PaymentDraftSchema(marshmallow.Schema):
         missing=None,
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     interface_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceId"
+        allow_none=True, missing=None, data_key="interfaceId", attribute="interfaceId"
     )
     amount_planned = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="amountPlanned",
+        attribute="amountPlanned",
     )
     amount_authorized = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -79,9 +80,10 @@ class PaymentDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="amountAuthorized",
+        attribute="amountAuthorized",
     )
     authorized_until = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="authorizedUntil"
+        allow_none=True, missing=None, data_key="authorizedUntil", attribute="authorizedUntil"
     )
     amount_paid = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -89,6 +91,7 @@ class PaymentDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="amountPaid",
+        attribute="amountPaid",
     )
     amount_refunded = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -96,6 +99,7 @@ class PaymentDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="amountRefunded",
+        attribute="amountRefunded",
     )
     payment_method_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.PaymentMethodInfoSchema",
@@ -103,6 +107,7 @@ class PaymentDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="paymentMethodInfo",
+        attribute="paymentMethodInfo",
     )
     payment_status = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.PaymentStatusDraftSchema",
@@ -110,6 +115,7 @@ class PaymentDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="paymentStatus",
+        attribute="paymentStatus",
     )
     transactions = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.TransactionDraftSchema",
@@ -125,6 +131,7 @@ class PaymentDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="interfaceInteractions",
+        attribute="interfaceInteractions",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -145,7 +152,7 @@ class PaymentDraftSchema(marshmallow.Schema):
 class PaymentMethodInfoSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PaymentMethodInfo`."
     payment_interface = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="paymentInterface"
+        allow_none=True, missing=None, data_key="paymentInterface", attribute="paymentInterface"
     )
     method = marshmallow.fields.String(allow_none=True, missing=None)
     name = LocalizedStringField(allow_none=True, missing=None)
@@ -217,13 +224,13 @@ class PaymentSchema(LoggedResourceSchema):
         missing=None,
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
     interface_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceId"
+        allow_none=True, missing=None, data_key="interfaceId", attribute="interfaceId"
     )
     amount_planned = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -234,6 +241,7 @@ class PaymentSchema(LoggedResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="amountPlanned",
+        attribute="amountPlanned",
     )
     amount_authorized = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -245,9 +253,10 @@ class PaymentSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="amountAuthorized",
+        attribute="amountAuthorized",
     )
     authorized_until = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="authorizedUntil"
+        allow_none=True, missing=None, data_key="authorizedUntil", attribute="authorizedUntil"
     )
     amount_paid = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -259,6 +268,7 @@ class PaymentSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="amountPaid",
+        attribute="amountPaid",
     )
     amount_refunded = helpers.Discriminator(
         discriminator_field=("type", "type"),
@@ -270,18 +280,21 @@ class PaymentSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="amountRefunded",
+        attribute="amountRefunded",
     )
     payment_method_info = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.PaymentMethodInfoSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="paymentMethodInfo",
+        attribute="paymentMethodInfo",
     )
     payment_status = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.PaymentStatusSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="paymentStatus",
+        attribute="paymentStatus",
     )
     transactions = marshmallow.fields.Nested(
         nested="commercetools.schemas._payment.TransactionSchema",
@@ -295,6 +308,7 @@ class PaymentSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="interfaceInteractions",
+        attribute="interfaceInteractions",
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
@@ -315,10 +329,10 @@ class PaymentSchema(LoggedResourceSchema):
 class PaymentStatusDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PaymentStatusDraft`."
     interface_code = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceCode"
+        allow_none=True, missing=None, data_key="interfaceCode", attribute="interfaceCode"
     )
     interface_text = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceText"
+        allow_none=True, missing=None, data_key="interfaceText", attribute="interfaceText"
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
@@ -338,10 +352,10 @@ class PaymentStatusDraftSchema(marshmallow.Schema):
 class PaymentStatusSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PaymentStatus`."
     interface_code = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceCode"
+        allow_none=True, missing=None, data_key="interfaceCode", attribute="interfaceCode"
     )
     interface_text = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceText"
+        allow_none=True, missing=None, data_key="interfaceText", attribute="interfaceText"
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
@@ -425,7 +439,7 @@ class TransactionDraftSchema(marshmallow.Schema):
         allow_none=True,
     )
     interaction_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interactionId"
+        allow_none=True, missing=None, data_key="interactionId", attribute="interactionId"
     )
     state = marshmallow_enum.EnumField(
         types.TransactionState, by_value=True, missing=None
@@ -454,7 +468,7 @@ class TransactionSchema(marshmallow.Schema):
         allow_none=True,
     )
     interaction_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interactionId"
+        allow_none=True, missing=None, data_key="interactionId", attribute="interactionId"
     )
     state = marshmallow_enum.EnumField(
         types.TransactionState, by_value=True, missing=None
@@ -523,10 +537,10 @@ class PaymentChangeAmountPlannedActionSchema(PaymentUpdateActionSchema):
 class PaymentChangeTransactionInteractionIdActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentChangeTransactionInteractionIdAction`."
     transaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="transactionId"
+        allow_none=True, data_key="transactionId", attribute="transactionId"
     )
     interaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="interactionId"
+        allow_none=True, data_key="interactionId", attribute="interactionId"
     )
 
     class Meta:
@@ -541,7 +555,7 @@ class PaymentChangeTransactionInteractionIdActionSchema(PaymentUpdateActionSchem
 class PaymentChangeTransactionStateActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentChangeTransactionStateAction`."
     transaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="transactionId"
+        allow_none=True, data_key="transactionId", attribute="transactionId"
     )
     state = marshmallow_enum.EnumField(types.TransactionState, by_value=True)
 
@@ -557,7 +571,7 @@ class PaymentChangeTransactionStateActionSchema(PaymentUpdateActionSchema):
 class PaymentChangeTransactionTimestampActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentChangeTransactionTimestampAction`."
     transaction_id = marshmallow.fields.String(
-        allow_none=True, data_key="transactionId"
+        allow_none=True, data_key="transactionId", attribute="transactionId"
     )
     timestamp = marshmallow.fields.DateTime(allow_none=True)
 
@@ -609,7 +623,7 @@ class PaymentSetAmountRefundedActionSchema(PaymentUpdateActionSchema):
 class PaymentSetAnonymousIdActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentSetAnonymousIdAction`."
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -694,7 +708,7 @@ class PaymentSetCustomerActionSchema(PaymentUpdateActionSchema):
 class PaymentSetExternalIdActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentSetExternalIdAction`."
     external_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="externalId"
+        allow_none=True, missing=None, data_key="externalId", attribute="externalId"
     )
 
     class Meta:
@@ -708,7 +722,7 @@ class PaymentSetExternalIdActionSchema(PaymentUpdateActionSchema):
 
 class PaymentSetInterfaceIdActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentSetInterfaceIdAction`."
-    interface_id = marshmallow.fields.String(allow_none=True, data_key="interfaceId")
+    interface_id = marshmallow.fields.String(allow_none=True, data_key="interfaceId", attribute="interfaceId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -774,7 +788,7 @@ class PaymentSetMethodInfoNameActionSchema(PaymentUpdateActionSchema):
 class PaymentSetStatusInterfaceCodeActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentSetStatusInterfaceCodeAction`."
     interface_code = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="interfaceCode"
+        allow_none=True, missing=None, data_key="interfaceCode", attribute="interfaceCode"
     )
 
     class Meta:
@@ -789,7 +803,7 @@ class PaymentSetStatusInterfaceCodeActionSchema(PaymentUpdateActionSchema):
 class PaymentSetStatusInterfaceTextActionSchema(PaymentUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.PaymentSetStatusInterfaceTextAction`."
     interface_text = marshmallow.fields.String(
-        allow_none=True, data_key="interfaceText"
+        allow_none=True, data_key="interfaceText", attribute="interfaceText"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_product.py
+++ b/src/commercetools/schemas/_product.py
@@ -118,13 +118,13 @@ class AttributeSchema(marshmallow.Schema):
 
 class FacetResultRangeSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.FacetResultRange`."
-    from_ = marshmallow.fields.Integer(allow_none=True, data_key="from")
-    from_str = marshmallow.fields.String(allow_none=True, data_key="fromStr")
+    from_ = marshmallow.fields.Integer(allow_none=True, data_key="from", attribute="from")
+    from_str = marshmallow.fields.String(allow_none=True, data_key="fromStr", attribute="fromStr")
     to = marshmallow.fields.Integer(allow_none=True)
-    to_str = marshmallow.fields.String(allow_none=True, data_key="toStr")
+    to_str = marshmallow.fields.String(allow_none=True, data_key="toStr", attribute="toStr")
     count = marshmallow.fields.Integer(allow_none=True)
     product_count = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="productCount"
+        allow_none=True, missing=None, data_key="productCount", attribute="productCount"
     )
     total = marshmallow.fields.Integer(allow_none=True)
     min = marshmallow.fields.Integer(allow_none=True)
@@ -157,7 +157,7 @@ class FacetResultTermSchema(marshmallow.Schema):
     term = marshmallow.fields.Raw(allow_none=True)
     count = marshmallow.fields.Integer(allow_none=True)
     product_count = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="productCount"
+        allow_none=True, missing=None, data_key="productCount", attribute="productCount"
     )
 
     class Meta:
@@ -223,7 +223,7 @@ class ProductCatalogDataSchema(marshmallow.Schema):
         allow_none=True,
     )
     has_staged_changes = marshmallow.fields.Bool(
-        allow_none=True, data_key="hasStagedChanges"
+        allow_none=True, data_key="hasStagedChanges", attribute="hasStagedChanges"
     )
 
     class Meta:
@@ -244,24 +244,25 @@ class ProductDataSchema(marshmallow.Schema):
         many=True,
     )
     category_order_hints = CategoryOrderHintsField(
-        allow_none=True, missing=None, data_key="categoryOrderHints"
+        allow_none=True, missing=None, data_key="categoryOrderHints", attribute="categoryOrderHints"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
     slug = LocalizedStringField(allow_none=True)
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     master_variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="masterVariant",
+        attribute="masterVariant",
     )
     variants = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
@@ -274,6 +275,7 @@ class ProductDataSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="searchKeywords",
+        attribute="searchKeywords",
     )
 
     class Meta:
@@ -291,6 +293,7 @@ class ProductDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productType",
+        attribute="productType",
     )
     name = LocalizedStringField(allow_none=True)
     slug = LocalizedStringField(allow_none=True)
@@ -304,16 +307,16 @@ class ProductDraftSchema(marshmallow.Schema):
         missing=None,
     )
     category_order_hints = CategoryOrderHintsField(
-        allow_none=True, missing=None, data_key="categoryOrderHints"
+        allow_none=True, missing=None, data_key="categoryOrderHints", attribute="categoryOrderHints"
     )
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     master_variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantDraftSchema",
@@ -321,6 +324,7 @@ class ProductDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="masterVariant",
+        attribute="masterVariant",
     )
     variants = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantDraftSchema",
@@ -335,6 +339,7 @@ class ProductDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     search_keywords = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.SearchKeywordsSchema",
@@ -342,6 +347,7 @@ class ProductDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="searchKeywords",
+        attribute="searchKeywords",
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateResourceIdentifierSchema",
@@ -432,6 +438,7 @@ class ProductProjectionSchema(BaseResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productType",
+        attribute="productType",
     )
     name = LocalizedStringField(allow_none=True)
     description = LocalizedStringField(allow_none=True, missing=None)
@@ -443,16 +450,16 @@ class ProductProjectionSchema(BaseResourceSchema):
         many=True,
     )
     category_order_hints = CategoryOrderHintsField(
-        allow_none=True, missing=None, data_key="categoryOrderHints"
+        allow_none=True, missing=None, data_key="categoryOrderHints", attribute="categoryOrderHints"
     )
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     search_keywords = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.SearchKeywordsSchema",
@@ -460,9 +467,10 @@ class ProductProjectionSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="searchKeywords",
+        attribute="searchKeywords",
     )
     has_staged_changes = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="hasStagedChanges"
+        allow_none=True, missing=None, data_key="hasStagedChanges", attribute="hasStagedChanges"
     )
     published = marshmallow.fields.Bool(allow_none=True, missing=None)
     master_variant = marshmallow.fields.Nested(
@@ -470,6 +478,7 @@ class ProductProjectionSchema(BaseResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="masterVariant",
+        attribute="masterVariant",
     )
     variants = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
@@ -483,6 +492,7 @@ class ProductProjectionSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
@@ -496,6 +506,7 @@ class ProductProjectionSchema(BaseResourceSchema):
         allow_none=True,
         missing=None,
         data_key="reviewRatingStatistics",
+        attribute="reviewRatingStatistics",
     )
 
     class Meta:
@@ -544,12 +555,14 @@ class ProductSchema(LoggedResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="productType",
+        attribute="productType",
     )
     master_data = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductCatalogDataSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="masterData",
+        attribute="masterData",
     )
     tax_category = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxCategoryReferenceSchema",
@@ -557,6 +570,7 @@ class ProductSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     state = marshmallow.fields.Nested(
         nested="commercetools.schemas._state.StateReferenceSchema",
@@ -570,6 +584,7 @@ class ProductSchema(LoggedResourceSchema):
         allow_none=True,
         missing=None,
         data_key="reviewRatingStatistics",
+        attribute="reviewRatingStatistics",
     )
 
     class Meta:
@@ -664,13 +679,13 @@ class ProductUpdateSchema(marshmallow.Schema):
 class ProductVariantAvailabilitySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ProductVariantAvailability`."
     is_on_stock = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isOnStock"
+        allow_none=True, missing=None, data_key="isOnStock", attribute="isOnStock"
     )
     restockable_in_days = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="restockableInDays"
+        allow_none=True, missing=None, data_key="restockableInDays", attribute="restockableInDays"
     )
     available_quantity = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="availableQuantity"
+        allow_none=True, missing=None, data_key="availableQuantity", attribute="availableQuantity"
     )
     channels = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantChannelAvailabilityMapSchema",
@@ -726,13 +741,13 @@ class ProductVariantChannelAvailabilityMapSchema(marshmallow.Schema):
 class ProductVariantChannelAvailabilitySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ProductVariantChannelAvailability`."
     is_on_stock = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isOnStock"
+        allow_none=True, missing=None, data_key="isOnStock", attribute="isOnStock"
     )
     restockable_in_days = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="restockableInDays"
+        allow_none=True, missing=None, data_key="restockableInDays", attribute="restockableInDays"
     )
     available_quantity = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="availableQuantity"
+        allow_none=True, missing=None, data_key="availableQuantity", attribute="availableQuantity"
     )
 
     class Meta:
@@ -830,7 +845,7 @@ class ProductVariantSchema(marshmallow.Schema):
         missing=None,
     )
     is_matching_variant = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isMatchingVariant"
+        allow_none=True, missing=None, data_key="isMatchingVariant", attribute="isMatchingVariant"
     )
     scoped_price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.ScopedPriceSchema",
@@ -838,9 +853,10 @@ class ProductVariantSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="scopedPrice",
+        attribute="scopedPrice",
     )
     scoped_price_discounted = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="scopedPriceDiscounted"
+        allow_none=True, missing=None, data_key="scopedPriceDiscounted", attribute="scopedPriceDiscounted"
     )
 
     class Meta:
@@ -864,6 +880,7 @@ class SearchKeywordSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="suggestTokenizer",
+        attribute="suggestTokenizer",
     )
 
     class Meta:
@@ -992,7 +1009,7 @@ class FilteredFacetResultSchema(FacetResultSchema):
     "Marshmallow schema for :class:`commercetools.types.FilteredFacetResult`."
     count = marshmallow.fields.Integer(allow_none=True)
     product_count = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="productCount"
+        allow_none=True, missing=None, data_key="productCount", attribute="productCount"
     )
 
     class Meta:
@@ -1007,7 +1024,7 @@ class FilteredFacetResultSchema(FacetResultSchema):
 class ProductAddAssetActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductAddAssetAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
@@ -1030,7 +1047,7 @@ class ProductAddAssetActionSchema(ProductUpdateActionSchema):
 class ProductAddExternalImageActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductAddExternalImageAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     image = marshmallow.fields.Nested(
@@ -1052,7 +1069,7 @@ class ProductAddExternalImageActionSchema(ProductUpdateActionSchema):
 class ProductAddPriceActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductAddPriceAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     price = marshmallow.fields.Nested(
@@ -1079,7 +1096,7 @@ class ProductAddToCategoryActionSchema(ProductUpdateActionSchema):
         allow_none=True,
     )
     order_hint = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderHint"
+        allow_none=True, missing=None, data_key="orderHint", attribute="orderHint"
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1138,15 +1155,15 @@ class ProductAddVariantActionSchema(ProductUpdateActionSchema):
 class ProductChangeAssetNameActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductChangeAssetNameAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     name = LocalizedStringField(allow_none=True)
 
@@ -1162,12 +1179,12 @@ class ProductChangeAssetNameActionSchema(ProductUpdateActionSchema):
 class ProductChangeAssetOrderActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductChangeAssetOrderAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_order = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="assetOrder"
+        marshmallow.fields.String(allow_none=True), data_key="assetOrder", attribute="assetOrder"
     )
 
     class Meta:
@@ -1182,7 +1199,7 @@ class ProductChangeAssetOrderActionSchema(ProductUpdateActionSchema):
 class ProductChangeMasterVariantActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductChangeMasterVariantAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
@@ -1212,7 +1229,7 @@ class ProductChangeNameActionSchema(ProductUpdateActionSchema):
 
 class ProductChangePriceActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductChangePriceAction`."
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.PriceDraftSchema",
         unknown=marshmallow.EXCLUDE,
@@ -1246,7 +1263,7 @@ class ProductChangeSlugActionSchema(ProductUpdateActionSchema):
 class ProductLegacySetSkuActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductLegacySetSkuAction`."
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1260,10 +1277,10 @@ class ProductLegacySetSkuActionSchema(ProductUpdateActionSchema):
 class ProductMoveImageToPositionActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductMoveImageToPositionAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl")
+    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl", attribute="imageUrl")
     position = marshmallow.fields.Integer(allow_none=True)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1294,15 +1311,15 @@ class ProductPublishActionSchema(ProductUpdateActionSchema):
 class ProductRemoveAssetActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductRemoveAssetAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
 
     class Meta:
@@ -1335,10 +1352,10 @@ class ProductRemoveFromCategoryActionSchema(ProductUpdateActionSchema):
 class ProductRemoveImageActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductRemoveImageAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
-    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl")
+    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl", attribute="imageUrl")
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
     class Meta:
@@ -1352,7 +1369,7 @@ class ProductRemoveImageActionSchema(ProductUpdateActionSchema):
 
 class ProductRemovePriceActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductRemovePriceAction`."
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
     class Meta:
@@ -1393,7 +1410,7 @@ class ProductRevertStagedChangesActionSchema(ProductUpdateActionSchema):
 
 class ProductRevertStagedVariantChangesActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductRevertStagedVariantChangesAction`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -1407,15 +1424,15 @@ class ProductRevertStagedVariantChangesActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetCustomFieldActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetCustomFieldAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -1432,15 +1449,15 @@ class ProductSetAssetCustomFieldActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetCustomTypeActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetCustomTypeAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -1462,15 +1479,15 @@ class ProductSetAssetCustomTypeActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetDescriptionActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetDescriptionAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
 
@@ -1486,13 +1503,13 @@ class ProductSetAssetDescriptionActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetKeyActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetKeyAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
-    asset_id = marshmallow.fields.String(allow_none=True, data_key="assetId")
+    asset_id = marshmallow.fields.String(allow_none=True, data_key="assetId", attribute="assetId")
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
 
     class Meta:
@@ -1507,15 +1524,15 @@ class ProductSetAssetKeyActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetSourcesActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetSourcesAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     sources = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.AssetSourceSchema",
@@ -1536,15 +1553,15 @@ class ProductSetAssetSourcesActionSchema(ProductUpdateActionSchema):
 class ProductSetAssetTagsActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAssetTagsAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     asset_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetId"
+        allow_none=True, missing=None, data_key="assetId", attribute="assetId"
     )
     asset_key = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="assetKey"
+        allow_none=True, missing=None, data_key="assetKey", attribute="assetKey"
     )
     tags = marshmallow.fields.List(
         marshmallow.fields.String(allow_none=True), missing=None
@@ -1562,7 +1579,7 @@ class ProductSetAssetTagsActionSchema(ProductUpdateActionSchema):
 class ProductSetAttributeActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetAttributeAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     name = marshmallow.fields.String(allow_none=True)
@@ -1595,9 +1612,9 @@ class ProductSetAttributeInAllVariantsActionSchema(ProductUpdateActionSchema):
 
 class ProductSetCategoryOrderHintActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetCategoryOrderHintAction`."
-    category_id = marshmallow.fields.String(allow_none=True, data_key="categoryId")
+    category_id = marshmallow.fields.String(allow_none=True, data_key="categoryId", attribute="categoryId")
     order_hint = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="orderHint"
+        allow_none=True, missing=None, data_key="orderHint", attribute="orderHint"
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1626,7 +1643,7 @@ class ProductSetDescriptionActionSchema(ProductUpdateActionSchema):
 
 class ProductSetDiscountedPriceActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetDiscountedPriceAction`."
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     discounted = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.DiscountedPriceSchema",
@@ -1648,9 +1665,9 @@ class ProductSetImageLabelActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetImageLabelAction`."
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
-    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl")
+    image_url = marshmallow.fields.String(allow_none=True, data_key="imageUrl", attribute="imageUrl")
     label = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1679,7 +1696,7 @@ class ProductSetKeyActionSchema(ProductUpdateActionSchema):
 class ProductSetMetaDescriptionActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetMetaDescriptionAction`."
     meta_description = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaDescription"
+        allow_none=True, missing=None, data_key="metaDescription", attribute="metaDescription"
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1695,7 +1712,7 @@ class ProductSetMetaDescriptionActionSchema(ProductUpdateActionSchema):
 class ProductSetMetaKeywordsActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetMetaKeywordsAction`."
     meta_keywords = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaKeywords"
+        allow_none=True, missing=None, data_key="metaKeywords", attribute="metaKeywords"
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1711,7 +1728,7 @@ class ProductSetMetaKeywordsActionSchema(ProductUpdateActionSchema):
 class ProductSetMetaTitleActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetMetaTitleAction`."
     meta_title = LocalizedStringField(
-        allow_none=True, missing=None, data_key="metaTitle"
+        allow_none=True, missing=None, data_key="metaTitle", attribute="metaTitle"
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1727,7 +1744,7 @@ class ProductSetMetaTitleActionSchema(ProductUpdateActionSchema):
 class ProductSetPricesActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetPricesAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     prices = marshmallow.fields.Nested(
@@ -1749,7 +1766,7 @@ class ProductSetPricesActionSchema(ProductUpdateActionSchema):
 
 class ProductSetProductPriceCustomFieldActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetProductPriceCustomFieldAction`."
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -1765,7 +1782,7 @@ class ProductSetProductPriceCustomFieldActionSchema(ProductUpdateActionSchema):
 
 class ProductSetProductPriceCustomTypeActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetProductPriceCustomTypeAction`."
-    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId")
+    price_id = marshmallow.fields.String(allow_none=True, data_key="priceId", attribute="priceId")
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -1787,7 +1804,7 @@ class ProductSetProductPriceCustomTypeActionSchema(ProductUpdateActionSchema):
 class ProductSetProductVariantKeyActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetProductVariantKeyAction`."
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     key = marshmallow.fields.String(allow_none=True, missing=None)
@@ -1809,6 +1826,7 @@ class ProductSetSearchKeywordsActionSchema(ProductUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="searchKeywords",
+        attribute="searchKeywords",
     )
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1823,7 +1841,7 @@ class ProductSetSearchKeywordsActionSchema(ProductUpdateActionSchema):
 
 class ProductSetSkuActionSchema(ProductUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductSetSkuAction`."
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     staged = marshmallow.fields.Bool(allow_none=True, missing=None)
 
@@ -1844,6 +1862,7 @@ class ProductSetTaxCategoryActionSchema(ProductUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
 
     class Meta:
@@ -1907,7 +1926,7 @@ class RangeFacetResultSchema(FacetResultSchema):
 class TermFacetResultSchema(FacetResultSchema):
     "Marshmallow schema for :class:`commercetools.types.TermFacetResult`."
     data_type = marshmallow_enum.EnumField(
-        types.TermFacetResultType, by_value=True, data_key="dataType"
+        types.TermFacetResultType, by_value=True, data_key="dataType", attribute="dataType"
     )
     missing = marshmallow.fields.Integer(allow_none=True)
     total = marshmallow.fields.Integer(allow_none=True)

--- a/src/commercetools/schemas/_product_discount.py
+++ b/src/commercetools/schemas/_product_discount.py
@@ -52,13 +52,13 @@ class ProductDiscountDraftSchema(marshmallow.Schema):
         allow_none=True,
     )
     predicate = marshmallow.fields.String(allow_none=True)
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -71,8 +71,8 @@ class ProductDiscountDraftSchema(marshmallow.Schema):
 
 class ProductDiscountMatchQuerySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountMatchQuery`."
-    product_id = marshmallow.fields.String(allow_none=True, data_key="productId")
-    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId")
+    product_id = marshmallow.fields.String(allow_none=True, data_key="productId", attribute="productId")
+    variant_id = marshmallow.fields.Integer(allow_none=True, data_key="variantId", attribute="variantId")
     staged = marshmallow.fields.Bool(allow_none=True)
     price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.PriceSchema",
@@ -154,8 +154,8 @@ class ProductDiscountSchema(LoggedResourceSchema):
         allow_none=True,
     )
     predicate = marshmallow.fields.String(allow_none=True)
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
     references = marshmallow.fields.List(
         helpers.Discriminator(
             discriminator_field=("typeId", "type_id"),
@@ -189,10 +189,10 @@ class ProductDiscountSchema(LoggedResourceSchema):
         )
     )
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -263,7 +263,7 @@ class ProductDiscountValueSchema(marshmallow.Schema):
 
 class ProductDiscountChangeIsActiveActionSchema(ProductDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountChangeIsActiveAction`."
-    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive")
+    is_active = marshmallow.fields.Bool(allow_none=True, data_key="isActive", attribute="isActive")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -302,7 +302,7 @@ class ProductDiscountChangePredicateActionSchema(ProductDiscountUpdateActionSche
 
 class ProductDiscountChangeSortOrderActionSchema(ProductDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountChangeSortOrderAction`."
-    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder")
+    sort_order = marshmallow.fields.String(allow_none=True, data_key="sortOrder", attribute="sortOrder")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -364,7 +364,7 @@ class ProductDiscountSetKeyActionSchema(ProductDiscountUpdateActionSchema):
 class ProductDiscountSetValidFromActionSchema(ProductDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountSetValidFromAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
 
     class Meta:
@@ -381,10 +381,10 @@ class ProductDiscountSetValidFromAndUntilActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountSetValidFromAndUntilAction`."
     valid_from = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validFrom"
+        allow_none=True, missing=None, data_key="validFrom", attribute="validFrom"
     )
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:
@@ -399,7 +399,7 @@ class ProductDiscountSetValidFromAndUntilActionSchema(
 class ProductDiscountSetValidUntilActionSchema(ProductDiscountUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductDiscountSetValidUntilAction`."
     valid_until = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="validUntil"
+        allow_none=True, missing=None, data_key="validUntil", attribute="validUntil"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_product_type.py
+++ b/src/commercetools/schemas/_product_type.py
@@ -85,19 +85,20 @@ class AttributeDefinitionDraftSchema(marshmallow.Schema):
     )
     name = marshmallow.fields.String(allow_none=True)
     label = LocalizedStringField(allow_none=True)
-    is_required = marshmallow.fields.Bool(allow_none=True, data_key="isRequired")
+    is_required = marshmallow.fields.Bool(allow_none=True, data_key="isRequired", attribute="isRequired")
     attribute_constraint = marshmallow_enum.EnumField(
         types.AttributeConstraintEnum,
         by_value=True,
         missing=None,
         data_key="attributeConstraint",
+        attribute="attributeConstraint",
     )
-    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip")
+    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip", attribute="inputTip")
     input_hint = marshmallow_enum.EnumField(
-        types.TextInputHint, by_value=True, missing=None, data_key="inputHint"
+        types.TextInputHint, by_value=True, missing=None, data_key="inputHint", attribute="inputHint"
     )
     is_searchable = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isSearchable"
+        allow_none=True, missing=None, data_key="isSearchable", attribute="isSearchable"
     )
 
     class Meta:
@@ -132,15 +133,15 @@ class AttributeDefinitionSchema(marshmallow.Schema):
     )
     name = marshmallow.fields.String(allow_none=True)
     label = LocalizedStringField(allow_none=True)
-    is_required = marshmallow.fields.Bool(allow_none=True, data_key="isRequired")
+    is_required = marshmallow.fields.Bool(allow_none=True, data_key="isRequired", attribute="isRequired")
     attribute_constraint = marshmallow_enum.EnumField(
-        types.AttributeConstraintEnum, by_value=True, data_key="attributeConstraint"
+        types.AttributeConstraintEnum, by_value=True, data_key="attributeConstraint", attribute="attributeConstraint"
     )
-    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip")
+    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip", attribute="inputTip")
     input_hint = marshmallow_enum.EnumField(
-        types.TextInputHint, by_value=True, data_key="inputHint"
+        types.TextInputHint, by_value=True, data_key="inputHint", attribute="inputHint"
     )
-    is_searchable = marshmallow.fields.Bool(allow_none=True, data_key="isSearchable")
+    is_searchable = marshmallow.fields.Bool(allow_none=True, data_key="isSearchable", attribute="isSearchable")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -440,6 +441,7 @@ class AttributeNestedTypeSchema(AttributeTypeSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="typeReference",
+        attribute="typeReference",
     )
 
     class Meta:
@@ -466,7 +468,7 @@ class AttributeNumberTypeSchema(AttributeTypeSchema):
 class AttributeReferenceTypeSchema(AttributeTypeSchema):
     "Marshmallow schema for :class:`commercetools.types.AttributeReferenceType`."
     reference_type_id = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, data_key="referenceTypeId"
+        types.ReferenceTypeId, by_value=True, data_key="referenceTypeId", attribute="referenceTypeId"
     )
 
     class Meta:
@@ -500,6 +502,7 @@ class AttributeSetTypeSchema(AttributeTypeSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="elementType",
+        attribute="elementType",
     )
 
     class Meta:
@@ -555,7 +558,7 @@ class ProductTypeAddAttributeDefinitionActionSchema(ProductTypeUpdateActionSchem
 class ProductTypeAddLocalizedEnumValueActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeAddLocalizedEnumValueAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributeLocalizedEnumValueSchema",
@@ -575,7 +578,7 @@ class ProductTypeAddLocalizedEnumValueActionSchema(ProductTypeUpdateActionSchema
 class ProductTypeAddPlainEnumValueActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeAddPlainEnumValueAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributePlainEnumValueSchema",
@@ -595,10 +598,10 @@ class ProductTypeAddPlainEnumValueActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangeAttributeConstraintActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeAttributeConstraintAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     new_value = marshmallow_enum.EnumField(
-        types.AttributeConstraintEnumDraft, by_value=True, data_key="newValue"
+        types.AttributeConstraintEnumDraft, by_value=True, data_key="newValue", attribute="newValue"
     )
 
     class Meta:
@@ -613,10 +616,10 @@ class ProductTypeChangeAttributeConstraintActionSchema(ProductTypeUpdateActionSc
 class ProductTypeChangeAttributeNameActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeAttributeNameAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     new_attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="newAttributeName"
+        allow_none=True, data_key="newAttributeName", attribute="newAttributeName"
     )
 
     class Meta:
@@ -649,7 +652,7 @@ class ProductTypeChangeAttributeOrderActionSchema(ProductTypeUpdateActionSchema)
 class ProductTypeChangeAttributeOrderByNameActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeAttributeOrderByNameAction`."
     attribute_names = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="attributeNames"
+        marshmallow.fields.String(allow_none=True), data_key="attributeNames", attribute="attributeNames"
     )
 
     class Meta:
@@ -677,10 +680,10 @@ class ProductTypeChangeDescriptionActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangeEnumKeyActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeEnumKeyAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     key = marshmallow.fields.String(allow_none=True)
-    new_key = marshmallow.fields.String(allow_none=True, data_key="newKey")
+    new_key = marshmallow.fields.String(allow_none=True, data_key="newKey", attribute="newKey")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -694,10 +697,10 @@ class ProductTypeChangeEnumKeyActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangeInputHintActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeInputHintAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     new_value = marshmallow_enum.EnumField(
-        types.TextInputHint, by_value=True, data_key="newValue"
+        types.TextInputHint, by_value=True, data_key="newValue", attribute="newValue"
     )
 
     class Meta:
@@ -712,9 +715,9 @@ class ProductTypeChangeInputHintActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangeIsSearchableActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeIsSearchableAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
-    is_searchable = marshmallow.fields.Bool(allow_none=True, data_key="isSearchable")
+    is_searchable = marshmallow.fields.Bool(allow_none=True, data_key="isSearchable", attribute="isSearchable")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -728,7 +731,7 @@ class ProductTypeChangeIsSearchableActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangeLabelActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeLabelAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     label = LocalizedStringField(allow_none=True)
 
@@ -746,13 +749,14 @@ class ProductTypeChangeLocalizedEnumValueLabelActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeLocalizedEnumValueLabelAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     new_value = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributeLocalizedEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="newValue",
+        attribute="newValue",
     )
 
     class Meta:
@@ -769,7 +773,7 @@ class ProductTypeChangeLocalizedEnumValueOrderActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangeLocalizedEnumValueOrderAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     values = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributeLocalizedEnumValueSchema",
@@ -803,13 +807,14 @@ class ProductTypeChangeNameActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeChangePlainEnumValueLabelActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangePlainEnumValueLabelAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     new_value = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributePlainEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="newValue",
+        attribute="newValue",
     )
 
     class Meta:
@@ -824,7 +829,7 @@ class ProductTypeChangePlainEnumValueLabelActionSchema(ProductTypeUpdateActionSc
 class ProductTypeChangePlainEnumValueOrderActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeChangePlainEnumValueOrderAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     values = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.AttributePlainEnumValueSchema",
@@ -858,7 +863,7 @@ class ProductTypeRemoveAttributeDefinitionActionSchema(ProductTypeUpdateActionSc
 class ProductTypeRemoveEnumValuesActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeRemoveEnumValuesAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
     keys = marshmallow.fields.List(marshmallow.fields.String(allow_none=True))
 
@@ -874,9 +879,9 @@ class ProductTypeRemoveEnumValuesActionSchema(ProductTypeUpdateActionSchema):
 class ProductTypeSetInputTipActionSchema(ProductTypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProductTypeSetInputTipAction`."
     attribute_name = marshmallow.fields.String(
-        allow_none=True, data_key="attributeName"
+        allow_none=True, data_key="attributeName", attribute="attributeName"
     )
-    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip")
+    input_tip = LocalizedStringField(allow_none=True, missing=None, data_key="inputTip", attribute="inputTip")
 
     class Meta:
         unknown = marshmallow.EXCLUDE

--- a/src/commercetools/schemas/_project.py
+++ b/src/commercetools/schemas/_project.py
@@ -29,7 +29,7 @@ class ExternalOAuthSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ExternalOAuth`."
     url = marshmallow.fields.String(allow_none=True)
     authorization_header = marshmallow.fields.String(
-        allow_none=True, data_key="authorizationHeader"
+        allow_none=True, data_key="authorizationHeader", attribute="authorizationHeader"
     )
 
     class Meta:
@@ -48,9 +48,9 @@ class ProjectSchema(marshmallow.Schema):
     countries = marshmallow.fields.List(marshmallow.fields.String())
     currencies = marshmallow.fields.List(marshmallow.fields.String())
     languages = marshmallow.fields.List(marshmallow.fields.String())
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     trial_until = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="trialUntil"
+        allow_none=True, missing=None, data_key="trialUntil", attribute="trialUntil"
     )
     messages = marshmallow.fields.Nested(
         nested="commercetools.schemas._message.MessageConfigurationSchema",
@@ -68,6 +68,7 @@ class ProjectSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInputType",
+        attribute="shippingRateInputType",
     )
     external_o_auth = marshmallow.fields.Nested(
         nested="commercetools.schemas._project.ExternalOAuthSchema",
@@ -75,6 +76,7 @@ class ProjectSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="externalOAuth",
+        attribute="externalOAuth",
     )
 
     class Meta:
@@ -231,6 +233,7 @@ class ProjectChangeMessagesConfigurationActionSchema(ProjectUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="messagesConfiguration",
+        attribute="messagesConfiguration",
     )
 
     class Meta:
@@ -245,7 +248,7 @@ class ProjectChangeMessagesConfigurationActionSchema(ProjectUpdateActionSchema):
 class ProjectChangeMessagesEnabledActionSchema(ProjectUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ProjectChangeMessagesEnabledAction`."
     messages_enabled = marshmallow.fields.Bool(
-        allow_none=True, data_key="messagesEnabled"
+        allow_none=True, data_key="messagesEnabled", attribute="messagesEnabled"
     )
 
     class Meta:
@@ -278,6 +281,7 @@ class ProjectSetExternalOAuthActionSchema(ProjectUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="externalOAuth",
+        attribute="externalOAuth",
     )
 
     class Meta:
@@ -302,6 +306,7 @@ class ProjectSetShippingRateInputTypeActionSchema(ProjectUpdateActionSchema):
         allow_none=True,
         missing=None,
         data_key="shippingRateInputType",
+        attribute="shippingRateInputType",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_review.py
+++ b/src/commercetools/schemas/_review.py
@@ -37,11 +37,11 @@ class ReviewDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ReviewDraft`."
     key = marshmallow.fields.String(allow_none=True, missing=None)
     uniqueness_value = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="uniquenessValue"
+        allow_none=True, missing=None, data_key="uniquenessValue", attribute="uniquenessValue"
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     author_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="authorName"
+        allow_none=True, missing=None, data_key="authorName", attribute="authorName"
     )
     title = marshmallow.fields.String(allow_none=True, missing=None)
     text = marshmallow.fields.String(allow_none=True, missing=None)
@@ -102,15 +102,15 @@ class ReviewPagedQueryResponseSchema(marshmallow.Schema):
 class ReviewRatingStatisticsSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ReviewRatingStatistics`."
     average_rating = marshmallow.fields.Integer(
-        allow_none=True, data_key="averageRating"
+        allow_none=True, data_key="averageRating", attribute="averageRating"
     )
     highest_rating = marshmallow.fields.Integer(
-        allow_none=True, data_key="highestRating"
+        allow_none=True, data_key="highestRating", attribute="highestRating"
     )
-    lowest_rating = marshmallow.fields.Integer(allow_none=True, data_key="lowestRating")
+    lowest_rating = marshmallow.fields.Integer(allow_none=True, data_key="lowestRating", attribute="lowestRating")
     count = marshmallow.fields.Integer(allow_none=True)
     ratings_distribution = marshmallow.fields.Dict(
-        allow_none=True, data_key="ratingsDistribution"
+        allow_none=True, data_key="ratingsDistribution", attribute="ratingsDistribution"
     )
 
     class Meta:
@@ -155,11 +155,11 @@ class ReviewSchema(LoggedResourceSchema):
     "Marshmallow schema for :class:`commercetools.types.Review`."
     key = marshmallow.fields.String(allow_none=True, missing=None)
     uniqueness_value = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="uniquenessValue"
+        allow_none=True, missing=None, data_key="uniquenessValue", attribute="uniquenessValue"
     )
     locale = marshmallow.fields.String(allow_none=True, missing=None)
     author_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="authorName"
+        allow_none=True, missing=None, data_key="authorName", attribute="authorName"
     )
     title = marshmallow.fields.String(allow_none=True, missing=None)
     text = marshmallow.fields.String(allow_none=True, missing=None)
@@ -170,7 +170,7 @@ class ReviewSchema(LoggedResourceSchema):
         missing=None,
     )
     included_in_statistics = marshmallow.fields.Bool(
-        allow_none=True, data_key="includedInStatistics"
+        allow_none=True, data_key="includedInStatistics", attribute="includedInStatistics"
     )
     rating = marshmallow.fields.Integer(allow_none=True, missing=None)
     state = marshmallow.fields.Nested(
@@ -249,7 +249,7 @@ class ReviewUpdateSchema(marshmallow.Schema):
 class ReviewSetAuthorNameActionSchema(ReviewUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ReviewSetAuthorNameAction`."
     author_name = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="authorName"
+        allow_none=True, missing=None, data_key="authorName", attribute="authorName"
     )
 
     class Meta:

--- a/src/commercetools/schemas/_shipping_method.py
+++ b/src/commercetools/schemas/_shipping_method.py
@@ -42,7 +42,7 @@ __all__ = [
 
 class PriceFunctionSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PriceFunction`."
-    currency_code = marshmallow.fields.String(data_key="currencyCode")
+    currency_code = marshmallow.fields.String(data_key="currencyCode", attribute="currencyCode")
     function = marshmallow.fields.String(allow_none=True)
 
     class Meta:
@@ -63,6 +63,7 @@ class ShippingMethodDraftSchema(marshmallow.Schema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     zone_rates = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ZoneRateDraftSchema",
@@ -70,8 +71,9 @@ class ShippingMethodDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="zoneRates",
+        attribute="zoneRates",
     )
-    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault")
+    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault", attribute="isDefault")
     predicate = marshmallow.fields.String(allow_none=True, missing=None)
 
     class Meta:
@@ -142,6 +144,7 @@ class ShippingMethodSchema(BaseResourceSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
     zone_rates = marshmallow.fields.Nested(
         nested="commercetools.schemas._shipping_method.ZoneRateSchema",
@@ -149,8 +152,9 @@ class ShippingMethodSchema(BaseResourceSchema):
         allow_none=True,
         many=True,
         data_key="zoneRates",
+        attribute="zoneRates",
     )
-    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault")
+    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault", attribute="isDefault")
     predicate = marshmallow.fields.String(allow_none=True, missing=None)
 
     class Meta:
@@ -219,6 +223,7 @@ class ShippingRateDraftSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="freeAbove",
+        attribute="freeAbove",
     )
     tiers = marshmallow.fields.List(
         helpers.Discriminator(
@@ -276,9 +281,10 @@ class ShippingRateSchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="freeAbove",
+        attribute="freeAbove",
     )
     is_matching = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isMatching"
+        allow_none=True, missing=None, data_key="isMatching", attribute="isMatching"
     )
     tiers = marshmallow.fields.List(
         helpers.Discriminator(
@@ -314,6 +320,7 @@ class ZoneRateDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="shippingRates",
+        attribute="shippingRates",
     )
 
     class Meta:
@@ -337,6 +344,7 @@ class ZoneRateSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         data_key="shippingRates",
+        attribute="shippingRates",
     )
 
     class Meta:
@@ -356,7 +364,7 @@ class CartClassificationTierSchema(ShippingRatePriceTierSchema):
         allow_none=True,
     )
     is_matching = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isMatching"
+        allow_none=True, missing=None, data_key="isMatching", attribute="isMatching"
     )
 
     class Meta:
@@ -383,9 +391,10 @@ class CartScoreTierSchema(ShippingRatePriceTierSchema):
         allow_none=True,
         missing=None,
         data_key="priceFunction",
+        attribute="priceFunction",
     )
     is_matching = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isMatching"
+        allow_none=True, missing=None, data_key="isMatching", attribute="isMatching"
     )
 
     class Meta:
@@ -400,7 +409,7 @@ class CartScoreTierSchema(ShippingRatePriceTierSchema):
 class CartValueTierSchema(ShippingRatePriceTierSchema):
     "Marshmallow schema for :class:`commercetools.types.CartValueTier`."
     minimum_cent_amount = marshmallow.fields.Integer(
-        allow_none=True, data_key="minimumCentAmount"
+        allow_none=True, data_key="minimumCentAmount", attribute="minimumCentAmount"
     )
     price = marshmallow.fields.Nested(
         nested="commercetools.schemas._common.MoneySchema",
@@ -408,7 +417,7 @@ class CartValueTierSchema(ShippingRatePriceTierSchema):
         allow_none=True,
     )
     is_matching = marshmallow.fields.Bool(
-        allow_none=True, missing=None, data_key="isMatching"
+        allow_none=True, missing=None, data_key="isMatching", attribute="isMatching"
     )
 
     class Meta:
@@ -432,6 +441,7 @@ class ShippingMethodAddShippingRateActionSchema(ShippingMethodUpdateActionSchema
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
 
     class Meta:
@@ -462,7 +472,7 @@ class ShippingMethodAddZoneActionSchema(ShippingMethodUpdateActionSchema):
 
 class ShippingMethodChangeIsDefaultActionSchema(ShippingMethodUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShippingMethodChangeIsDefaultAction`."
-    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault")
+    is_default = marshmallow.fields.Bool(allow_none=True, data_key="isDefault", attribute="isDefault")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -493,6 +503,7 @@ class ShippingMethodChangeTaxCategoryActionSchema(ShippingMethodUpdateActionSche
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxCategory",
+        attribute="taxCategory",
     )
 
     class Meta:
@@ -516,6 +527,7 @@ class ShippingMethodRemoveShippingRateActionSchema(ShippingMethodUpdateActionSch
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="shippingRate",
+        attribute="shippingRate",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_shopping_list.py
+++ b/src/commercetools/schemas/_shopping_list.py
@@ -64,7 +64,7 @@ class ShoppingListDraftSchema(marshmallow.Schema):
         missing=None,
     )
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
     key = marshmallow.fields.String(allow_none=True, missing=None)
@@ -74,7 +74,7 @@ class ShoppingListDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         missing=None,
-        data_key="lineItems",
+        data_key="lineItems", attribute="lineItems",
     )
     name = LocalizedStringField(allow_none=True)
     slug = LocalizedStringField(allow_none=True, missing=None)
@@ -84,10 +84,10 @@ class ShoppingListDraftSchema(marshmallow.Schema):
         allow_none=True,
         many=True,
         missing=None,
-        data_key="textLineItems",
+        data_key="textLineItems", attribute="textLineItems",
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -101,7 +101,7 @@ class ShoppingListDraftSchema(marshmallow.Schema):
 class ShoppingListLineItemDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListLineItemDraft`."
     added_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="addedAt"
+        allow_none=True, missing=None, data_key="addedAt", attribute="addedAt"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -111,11 +111,11 @@ class ShoppingListLineItemDraftSchema(marshmallow.Schema):
     )
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
 
     class Meta:
@@ -128,7 +128,7 @@ class ShoppingListLineItemDraftSchema(marshmallow.Schema):
 
 class ShoppingListLineItemSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListLineItem`."
-    added_at = marshmallow.fields.DateTime(allow_none=True, data_key="addedAt")
+    added_at = marshmallow.fields.DateTime(allow_none=True, data_key="addedAt", attribute="addedAt")
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -136,19 +136,19 @@ class ShoppingListLineItemSchema(marshmallow.Schema):
         missing=None,
     )
     deactivated_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="deactivatedAt"
+        allow_none=True, missing=None, data_key="deactivatedAt", attribute="deactivatedAt"
     )
     id = marshmallow.fields.String(allow_none=True)
     name = LocalizedStringField(allow_none=True)
-    product_id = marshmallow.fields.String(allow_none=True, data_key="productId")
+    product_id = marshmallow.fields.String(allow_none=True, data_key="productId", attribute="productId")
     product_slug = LocalizedStringField(
-        allow_none=True, missing=None, data_key="productSlug"
+        allow_none=True, missing=None, data_key="productSlug", attribute="productSlug"
     )
     product_type = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.ProductTypeReferenceSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
-        data_key="productType",
+        data_key="productType", attribute="productType",
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
     variant = marshmallow.fields.Nested(
@@ -158,7 +158,7 @@ class ShoppingListLineItemSchema(marshmallow.Schema):
         missing=None,
     )
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
 
     class Meta:
@@ -234,7 +234,7 @@ class ShoppingListSchema(LoggedResourceSchema):
         missing=None,
     )
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
     key = marshmallow.fields.String(allow_none=True, missing=None)
@@ -244,7 +244,7 @@ class ShoppingListSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         missing=None,
-        data_key="lineItems",
+        data_key="lineItems", attribute="lineItems",
     )
     name = LocalizedStringField(allow_none=True)
     slug = LocalizedStringField(allow_none=True, missing=None)
@@ -254,10 +254,10 @@ class ShoppingListSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         missing=None,
-        data_key="textLineItems",
+        data_key="textLineItems", attribute="textLineItems",
     )
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -329,7 +329,7 @@ class ShoppingListUpdateSchema(marshmallow.Schema):
 class TextLineItemDraftSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.TextLineItemDraft`."
     added_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="addedAt"
+        allow_none=True, missing=None, data_key="addedAt", attribute="addedAt"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -351,7 +351,7 @@ class TextLineItemDraftSchema(marshmallow.Schema):
 
 class TextLineItemSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.TextLineItem`."
-    added_at = marshmallow.fields.DateTime(allow_none=True, data_key="addedAt")
+    added_at = marshmallow.fields.DateTime(allow_none=True, data_key="addedAt", attribute="addedAt")
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsSchema",
         unknown=marshmallow.EXCLUDE,
@@ -375,14 +375,14 @@ class ShoppingListAddLineItemActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListAddLineItemAction`."
     sku = marshmallow.fields.String(allow_none=True, missing=None)
     product_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="productId"
+        allow_none=True, missing=None, data_key="productId", attribute="productId"
     )
     variant_id = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="variantId"
+        allow_none=True, missing=None, data_key="variantId", attribute="variantId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
     added_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="addedAt"
+        allow_none=True, missing=None, data_key="addedAt", attribute="addedAt"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -406,7 +406,7 @@ class ShoppingListAddTextLineItemActionSchema(ShoppingListUpdateActionSchema):
     description = LocalizedStringField(allow_none=True, missing=None)
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
     added_at = marshmallow.fields.DateTime(
-        allow_none=True, missing=None, data_key="addedAt"
+        allow_none=True, missing=None, data_key="addedAt", attribute="addedAt"
     )
     custom = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldsDraftSchema",
@@ -426,7 +426,7 @@ class ShoppingListAddTextLineItemActionSchema(ShoppingListUpdateActionSchema):
 
 class ShoppingListChangeLineItemQuantityActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListChangeLineItemQuantityAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True)
 
     class Meta:
@@ -441,7 +441,7 @@ class ShoppingListChangeLineItemQuantityActionSchema(ShoppingListUpdateActionSch
 class ShoppingListChangeLineItemsOrderActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListChangeLineItemsOrderAction`."
     line_item_order = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="lineItemOrder"
+        marshmallow.fields.String(allow_none=True), data_key="lineItemOrder", attribute="lineItemOrder"
     )
 
     class Meta:
@@ -469,7 +469,7 @@ class ShoppingListChangeNameActionSchema(ShoppingListUpdateActionSchema):
 class ShoppingListChangeTextLineItemNameActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListChangeTextLineItemNameAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     name = LocalizedStringField(allow_none=True)
 
@@ -487,7 +487,7 @@ class ShoppingListChangeTextLineItemQuantityActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListChangeTextLineItemQuantityAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True)
 
@@ -503,7 +503,7 @@ class ShoppingListChangeTextLineItemQuantityActionSchema(
 class ShoppingListChangeTextLineItemsOrderActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListChangeTextLineItemsOrderAction`."
     text_line_item_order = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="textLineItemOrder"
+        marshmallow.fields.String(allow_none=True), data_key="textLineItemOrder", attribute="textLineItemOrder"
     )
 
     class Meta:
@@ -517,7 +517,7 @@ class ShoppingListChangeTextLineItemsOrderActionSchema(ShoppingListUpdateActionS
 
 class ShoppingListRemoveLineItemActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListRemoveLineItemAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
 
     class Meta:
@@ -532,7 +532,7 @@ class ShoppingListRemoveLineItemActionSchema(ShoppingListUpdateActionSchema):
 class ShoppingListRemoveTextLineItemActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListRemoveTextLineItemAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     quantity = marshmallow.fields.Integer(allow_none=True, missing=None)
 
@@ -548,7 +548,7 @@ class ShoppingListRemoveTextLineItemActionSchema(ShoppingListUpdateActionSchema)
 class ShoppingListSetAnonymousIdActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetAnonymousIdAction`."
     anonymous_id = marshmallow.fields.String(
-        allow_none=True, missing=None, data_key="anonymousId"
+        allow_none=True, missing=None, data_key="anonymousId", attribute="anonymousId"
     )
 
     class Meta:
@@ -616,7 +616,7 @@ class ShoppingListSetDeleteDaysAfterLastModificationActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetDeleteDaysAfterLastModificationAction`."
     delete_days_after_last_modification = marshmallow.fields.Integer(
-        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification"
+        allow_none=True, missing=None, data_key="deleteDaysAfterLastModification", attribute="deleteDaysAfterLastModification"
     )
 
     class Meta:
@@ -656,7 +656,7 @@ class ShoppingListSetKeyActionSchema(ShoppingListUpdateActionSchema):
 
 class ShoppingListSetLineItemCustomFieldActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetLineItemCustomFieldAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
 
@@ -671,7 +671,7 @@ class ShoppingListSetLineItemCustomFieldActionSchema(ShoppingListUpdateActionSch
 
 class ShoppingListSetLineItemCustomTypeActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetLineItemCustomTypeAction`."
-    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId")
+    line_item_id = marshmallow.fields.String(allow_none=True, data_key="lineItemId", attribute="lineItemId")
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
         unknown=marshmallow.EXCLUDE,
@@ -707,7 +707,7 @@ class ShoppingListSetTextLineItemCustomFieldActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetTextLineItemCustomFieldAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     name = marshmallow.fields.String(allow_none=True)
     value = marshmallow.fields.Raw(allow_none=True, missing=None)
@@ -724,7 +724,7 @@ class ShoppingListSetTextLineItemCustomFieldActionSchema(
 class ShoppingListSetTextLineItemCustomTypeActionSchema(ShoppingListUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetTextLineItemCustomTypeAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     type = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.TypeResourceIdentifierSchema",
@@ -748,7 +748,7 @@ class ShoppingListSetTextLineItemDescriptionActionSchema(
 ):
     "Marshmallow schema for :class:`commercetools.types.ShoppingListSetTextLineItemDescriptionAction`."
     text_line_item_id = marshmallow.fields.String(
-        allow_none=True, data_key="textLineItemId"
+        allow_none=True, data_key="textLineItemId", attribute="textLineItemId"
     )
     description = LocalizedStringField(allow_none=True, missing=None)
 

--- a/src/commercetools/schemas/_state.py
+++ b/src/commercetools/schemas/_state.py
@@ -114,7 +114,7 @@ class StateSchema(LoggedResourceSchema):
     name = LocalizedStringField(allow_none=True, missing=None)
     description = LocalizedStringField(allow_none=True, missing=None)
     initial = marshmallow.fields.Bool(allow_none=True)
-    built_in = marshmallow.fields.Bool(allow_none=True, data_key="builtIn")
+    built_in = marshmallow.fields.Bool(allow_none=True, data_key="builtIn", attribute="builtIn")
     roles = marshmallow.fields.List(
         marshmallow_enum.EnumField(types.StateRoleEnum, by_value=True), missing=None
     )

--- a/src/commercetools/schemas/_subscription.py
+++ b/src/commercetools/schemas/_subscription.py
@@ -40,7 +40,7 @@ __all__ = [
 class ChangeSubscriptionSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.ChangeSubscription`."
     resource_type_id = marshmallow.fields.String(
-        allow_none=True, data_key="resourceTypeId"
+        allow_none=True, data_key="resourceTypeId", attribute="resourceTypeId"
     )
 
     class Meta:
@@ -80,7 +80,7 @@ class DestinationSchema(marshmallow.Schema):
 class MessageSubscriptionSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.MessageSubscription`."
     resource_type_id = marshmallow.fields.String(
-        allow_none=True, data_key="resourceTypeId"
+        allow_none=True, data_key="resourceTypeId", attribute="resourceTypeId"
     )
     types = marshmallow.fields.List(
         marshmallow.fields.String(allow_none=True), missing=None
@@ -97,7 +97,7 @@ class MessageSubscriptionSchema(marshmallow.Schema):
 class PayloadNotIncludedSchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.PayloadNotIncluded`."
     reason = marshmallow.fields.String(allow_none=True)
-    payload_type = marshmallow.fields.String(allow_none=True, data_key="payloadType")
+    payload_type = marshmallow.fields.String(allow_none=True, data_key="payloadType", attribute="payloadType")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -109,9 +109,9 @@ class PayloadNotIncludedSchema(marshmallow.Schema):
 
 class SubscriptionDeliverySchema(marshmallow.Schema):
     "Marshmallow schema for :class:`commercetools.types.SubscriptionDelivery`."
-    project_key = marshmallow.fields.String(allow_none=True, data_key="projectKey")
+    project_key = marshmallow.fields.String(allow_none=True, data_key="projectKey", attribute="projectKey")
     notification_type = marshmallow.fields.String(
-        allow_none=True, data_key="notificationType"
+        allow_none=True, data_key="notificationType", attribute="notificationType"
     )
     resource = helpers.Discriminator(
         discriminator_field=("typeId", "type_id"),
@@ -149,6 +149,7 @@ class SubscriptionDeliverySchema(marshmallow.Schema):
         allow_none=True,
         missing=None,
         data_key="resourceUserProvidedIdentifiers",
+        attribute="resourceUserProvidedIdentifiers",
     )
 
     class Meta:
@@ -318,7 +319,7 @@ class SubscriptionUpdateSchema(marshmallow.Schema):
 class AzureEventGridDestinationSchema(DestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.AzureEventGridDestination`."
     uri = marshmallow.fields.String(allow_none=True)
-    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey")
+    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey", attribute="accessKey")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -332,7 +333,7 @@ class AzureEventGridDestinationSchema(DestinationSchema):
 class AzureServiceBusDestinationSchema(DestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.AzureServiceBusDestination`."
     connection_string = marshmallow.fields.String(
-        allow_none=True, data_key="connectionString"
+        allow_none=True, data_key="connectionString", attribute="connectionString"
     )
 
     class Meta:
@@ -347,7 +348,7 @@ class AzureServiceBusDestinationSchema(DestinationSchema):
 class DeliveryCloudEventsFormatSchema(DeliveryFormatSchema):
     "Marshmallow schema for :class:`commercetools.types.DeliveryCloudEventsFormat`."
     cloud_events_version = marshmallow.fields.String(
-        allow_none=True, data_key="cloudEventsVersion"
+        allow_none=True, data_key="cloudEventsVersion", attribute="cloudEventsVersion"
     )
 
     class Meta:
@@ -373,7 +374,7 @@ class DeliveryPlatformFormatSchema(DeliveryFormatSchema):
 
 class GoogleCloudPubSubDestinationSchema(DestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.GoogleCloudPubSubDestination`."
-    project_id = marshmallow.fields.String(allow_none=True, data_key="projectId")
+    project_id = marshmallow.fields.String(allow_none=True, data_key="projectId", attribute="projectId")
     topic = marshmallow.fields.String(allow_none=True)
 
     class Meta:
@@ -402,21 +403,22 @@ class MessageDeliverySchema(SubscriptionDeliverySchema):
     "Marshmallow schema for :class:`commercetools.types.MessageDelivery`."
     id = marshmallow.fields.String(allow_none=True)
     version = marshmallow.fields.Integer(allow_none=True)
-    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt")
+    created_at = marshmallow.fields.DateTime(allow_none=True, data_key="createdAt", attribute="createdAt")
     last_modified_at = marshmallow.fields.DateTime(
-        allow_none=True, data_key="lastModifiedAt"
+        allow_none=True, data_key="lastModifiedAt", attribute="lastModifiedAt"
     )
     sequence_number = marshmallow.fields.Integer(
-        allow_none=True, data_key="sequenceNumber"
+        allow_none=True, data_key="sequenceNumber", attribute="sequenceNumber"
     )
     resource_version = marshmallow.fields.Integer(
-        allow_none=True, data_key="resourceVersion"
+        allow_none=True, data_key="resourceVersion", attribute="resourceVersion"
     )
     payload_not_included = marshmallow.fields.Nested(
         nested="commercetools.schemas._subscription.PayloadNotIncludedSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="payloadNotIncluded",
+        attribute="payloadNotIncluded",
     )
 
     class Meta:
@@ -431,7 +433,7 @@ class MessageDeliverySchema(SubscriptionDeliverySchema):
 class ResourceCreatedDeliverySchema(SubscriptionDeliverySchema):
     "Marshmallow schema for :class:`commercetools.types.ResourceCreatedDelivery`."
     version = marshmallow.fields.Integer(allow_none=True)
-    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt")
+    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt", attribute="modifiedAt")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -445,7 +447,7 @@ class ResourceCreatedDeliverySchema(SubscriptionDeliverySchema):
 class ResourceDeletedDeliverySchema(SubscriptionDeliverySchema):
     "Marshmallow schema for :class:`commercetools.types.ResourceDeletedDelivery`."
     version = marshmallow.fields.Integer(allow_none=True)
-    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt")
+    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt", attribute="modifiedAt")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -459,8 +461,8 @@ class ResourceDeletedDeliverySchema(SubscriptionDeliverySchema):
 class ResourceUpdatedDeliverySchema(SubscriptionDeliverySchema):
     "Marshmallow schema for :class:`commercetools.types.ResourceUpdatedDelivery`."
     version = marshmallow.fields.Integer(allow_none=True)
-    old_version = marshmallow.fields.Integer(allow_none=True, data_key="oldVersion")
-    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt")
+    old_version = marshmallow.fields.Integer(allow_none=True, data_key="oldVersion", attribute="oldVersion")
+    modified_at = marshmallow.fields.DateTime(allow_none=True, data_key="modifiedAt", attribute="modifiedAt")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -473,9 +475,9 @@ class ResourceUpdatedDeliverySchema(SubscriptionDeliverySchema):
 
 class SnsDestinationSchema(DestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.SnsDestination`."
-    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey")
-    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret")
-    topic_arn = marshmallow.fields.String(allow_none=True, data_key="topicArn")
+    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey", attribute="accessKey")
+    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret", attribute="accessSecret")
+    topic_arn = marshmallow.fields.String(allow_none=True, data_key="topicArn", attribute="topicArn")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -488,9 +490,9 @@ class SnsDestinationSchema(DestinationSchema):
 
 class SqsDestinationSchema(DestinationSchema):
     "Marshmallow schema for :class:`commercetools.types.SqsDestination`."
-    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey")
-    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret")
-    queue_url = marshmallow.fields.String(allow_none=True, data_key="queueUrl")
+    access_key = marshmallow.fields.String(allow_none=True, data_key="accessKey", attribute="accessKey")
+    access_secret = marshmallow.fields.String(allow_none=True, data_key="accessSecret", attribute="accessSecret")
+    queue_url = marshmallow.fields.String(allow_none=True, data_key="queueUrl", attribute="queueUrl")
     region = marshmallow.fields.String(allow_none=True)
 
     class Meta:

--- a/src/commercetools/schemas/_tax_category.py
+++ b/src/commercetools/schemas/_tax_category.py
@@ -178,7 +178,7 @@ class TaxRateDraftSchema(marshmallow.Schema):
     name = marshmallow.fields.String(allow_none=True)
     amount = marshmallow.fields.Float(allow_none=True, missing=None)
     included_in_price = marshmallow.fields.Bool(
-        allow_none=True, data_key="includedInPrice"
+        allow_none=True, data_key="includedInPrice", attribute="includedInPrice"
     )
     country = marshmallow.fields.String()
     state = marshmallow.fields.String(allow_none=True, missing=None)
@@ -189,6 +189,7 @@ class TaxRateDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="subRates",
+        attribute="subRates",
     )
 
     class Meta:
@@ -205,7 +206,7 @@ class TaxRateSchema(marshmallow.Schema):
     name = marshmallow.fields.String(allow_none=True)
     amount = marshmallow.fields.Float(allow_none=True)
     included_in_price = marshmallow.fields.Bool(
-        allow_none=True, data_key="includedInPrice"
+        allow_none=True, data_key="includedInPrice", attribute="includedInPrice"
     )
     country = marshmallow.fields.String()
     state = marshmallow.fields.String(allow_none=True, missing=None)
@@ -216,6 +217,7 @@ class TaxRateSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="subRates",
+        attribute="subRates",
     )
 
     class Meta:
@@ -233,6 +235,7 @@ class TaxCategoryAddTaxRateActionSchema(TaxCategoryUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxRate",
+        attribute="taxRate",
     )
 
     class Meta:
@@ -259,7 +262,7 @@ class TaxCategoryChangeNameActionSchema(TaxCategoryUpdateActionSchema):
 
 class TaxCategoryRemoveTaxRateActionSchema(TaxCategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TaxCategoryRemoveTaxRateAction`."
-    tax_rate_id = marshmallow.fields.String(allow_none=True, data_key="taxRateId")
+    tax_rate_id = marshmallow.fields.String(allow_none=True, data_key="taxRateId", attribute="taxRateId")
 
     class Meta:
         unknown = marshmallow.EXCLUDE
@@ -272,12 +275,13 @@ class TaxCategoryRemoveTaxRateActionSchema(TaxCategoryUpdateActionSchema):
 
 class TaxCategoryReplaceTaxRateActionSchema(TaxCategoryUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TaxCategoryReplaceTaxRateAction`."
-    tax_rate_id = marshmallow.fields.String(allow_none=True, data_key="taxRateId")
+    tax_rate_id = marshmallow.fields.String(allow_none=True, data_key="taxRateId", attribute="taxRateId")
     tax_rate = marshmallow.fields.Nested(
         nested="commercetools.schemas._tax_category.TaxRateDraftSchema",
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="taxRate",
+        attribute="taxRate",
     )
 
     class Meta:

--- a/src/commercetools/schemas/_type.py
+++ b/src/commercetools/schemas/_type.py
@@ -128,7 +128,7 @@ class FieldDefinitionSchema(marshmallow.Schema):
     label = LocalizedStringField(allow_none=True)
     required = marshmallow.fields.Bool(allow_none=True)
     input_hint = marshmallow_enum.EnumField(
-        types.TypeTextInputHint, by_value=True, missing=None, data_key="inputHint"
+        types.TypeTextInputHint, by_value=True, missing=None, data_key="inputHint", attribute="inputHint"
     )
 
     class Meta:
@@ -160,6 +160,7 @@ class TypeDraftSchema(marshmallow.Schema):
     resource_type_ids = marshmallow.fields.List(
         marshmallow_enum.EnumField(types.ResourceTypeId, by_value=True),
         data_key="resourceTypeIds",
+        attribute="resourceTypeIds",
     )
     field_definitions = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.FieldDefinitionSchema",
@@ -168,6 +169,7 @@ class TypeDraftSchema(marshmallow.Schema):
         many=True,
         missing=None,
         data_key="fieldDefinitions",
+        attribute="fieldDefinitions",
     )
 
     class Meta:
@@ -236,6 +238,7 @@ class TypeSchema(LoggedResourceSchema):
     resource_type_ids = marshmallow.fields.List(
         marshmallow_enum.EnumField(types.ResourceTypeId, by_value=True),
         data_key="resourceTypeIds",
+        attribute="resourceTypeIds",
     )
     field_definitions = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.FieldDefinitionSchema",
@@ -243,6 +246,7 @@ class TypeSchema(LoggedResourceSchema):
         allow_none=True,
         many=True,
         data_key="fieldDefinitions",
+        attribute="fieldDefinitions",
     )
 
     class Meta:
@@ -414,7 +418,7 @@ class CustomFieldNumberTypeSchema(FieldTypeSchema):
 class CustomFieldReferenceTypeSchema(FieldTypeSchema):
     "Marshmallow schema for :class:`commercetools.types.CustomFieldReferenceType`."
     reference_type_id = marshmallow_enum.EnumField(
-        types.ReferenceTypeId, by_value=True, data_key="referenceTypeId"
+        types.ReferenceTypeId, by_value=True, data_key="referenceTypeId", attribute="referenceTypeId"
     )
 
     class Meta:
@@ -447,6 +451,7 @@ class CustomFieldSetTypeSchema(FieldTypeSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="elementType",
+        attribute="elementType",
     )
 
     class Meta:
@@ -484,7 +489,7 @@ class CustomFieldTimeTypeSchema(FieldTypeSchema):
 
 class TypeAddEnumValueActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeAddEnumValueAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
@@ -507,6 +512,7 @@ class TypeAddFieldDefinitionActionSchema(TypeUpdateActionSchema):
         unknown=marshmallow.EXCLUDE,
         allow_none=True,
         data_key="fieldDefinition",
+        attribute="fieldDefinition",
     )
 
     class Meta:
@@ -520,7 +526,7 @@ class TypeAddFieldDefinitionActionSchema(TypeUpdateActionSchema):
 
 class TypeAddLocalizedEnumValueActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeAddLocalizedEnumValueAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldLocalizedEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
@@ -538,7 +544,7 @@ class TypeAddLocalizedEnumValueActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeEnumValueLabelActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeEnumValueLabelAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
@@ -556,7 +562,7 @@ class TypeChangeEnumValueLabelActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeEnumValueOrderActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeEnumValueOrderAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     keys = marshmallow.fields.List(marshmallow.fields.String(allow_none=True))
 
     class Meta:
@@ -570,7 +576,7 @@ class TypeChangeEnumValueOrderActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeFieldDefinitionLabelActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeFieldDefinitionLabelAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     label = LocalizedStringField(allow_none=True)
 
     class Meta:
@@ -585,7 +591,7 @@ class TypeChangeFieldDefinitionLabelActionSchema(TypeUpdateActionSchema):
 class TypeChangeFieldDefinitionOrderActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeFieldDefinitionOrderAction`."
     field_names = marshmallow.fields.List(
-        marshmallow.fields.String(allow_none=True), data_key="fieldNames"
+        marshmallow.fields.String(allow_none=True), data_key="fieldNames", attribute="fieldNames"
     )
 
     class Meta:
@@ -599,9 +605,9 @@ class TypeChangeFieldDefinitionOrderActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeInputHintActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeInputHintAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     input_hint = marshmallow_enum.EnumField(
-        types.TypeTextInputHint, by_value=True, data_key="inputHint"
+        types.TypeTextInputHint, by_value=True, data_key="inputHint", attribute="inputHint"
     )
 
     class Meta:
@@ -628,7 +634,7 @@ class TypeChangeKeyActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeLabelActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeLabelAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     label = LocalizedStringField(allow_none=True)
 
     class Meta:
@@ -642,7 +648,7 @@ class TypeChangeLabelActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeLocalizedEnumValueLabelActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeLocalizedEnumValueLabelAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     value = marshmallow.fields.Nested(
         nested="commercetools.schemas._type.CustomFieldLocalizedEnumValueSchema",
         unknown=marshmallow.EXCLUDE,
@@ -660,7 +666,7 @@ class TypeChangeLocalizedEnumValueLabelActionSchema(TypeUpdateActionSchema):
 
 class TypeChangeLocalizedEnumValueOrderActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeChangeLocalizedEnumValueOrderAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
     keys = marshmallow.fields.List(marshmallow.fields.String(allow_none=True))
 
     class Meta:
@@ -687,7 +693,7 @@ class TypeChangeNameActionSchema(TypeUpdateActionSchema):
 
 class TypeRemoveFieldDefinitionActionSchema(TypeUpdateActionSchema):
     "Marshmallow schema for :class:`commercetools.types.TypeRemoveFieldDefinitionAction`."
-    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName")
+    field_name = marshmallow.fields.String(allow_none=True, data_key="fieldName", attribute="fieldName")
 
     class Meta:
         unknown = marshmallow.EXCLUDE


### PR DESCRIPTION
I found that the serialization of schemas was not working as designed. The calls to `schema.dumps()` would generate data having keys in snake_case while commercetools backend was expecting json keys in camelCase.

Marshmallow allows the user to set data_key and attributes [parameters](https://marshmallow.readthedocs.io/en/3.0/api_reference.html#module-marshmallow.fields) when defining fields to define the keys to be used for de/serialization. Previously only `data_key` was used which told the schema what keys to look for when de-serializing, but we also need to pass `attributes` which defines the key that is used when dumping the json from the schema.

In this PR I simply use the same value passed to `data_key` and pass it additionally to `attributes` as well. This was done for all schema definitions in the `schemas` directory.