### PR TITLE
Fix product projection keys

### DIFF
--- a/src/commercetools/schemas/_product.py
+++ b/src/commercetools/schemas/_product.py
@@ -544,7 +544,8 @@ class ProductSchema(LoggedResourceSchema):
     product_type = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.ProductTypeReferenceSchema",
         unknown=marshmallow.EXCLUDE,
-        allow_none=True,
+        allow_none=False,
+        required=True,
         data_key="productType",
     )
     master_data = marshmallow.fields.Nested(

--- a/src/commercetools/schemas/_product.py
+++ b/src/commercetools/schemas/_product.py
@@ -430,7 +430,8 @@ class ProductProjectionSchema(BaseResourceSchema):
     product_type = marshmallow.fields.Nested(
         nested="commercetools.schemas._product_type.ProductTypeReferenceSchema",
         unknown=marshmallow.EXCLUDE,
-        allow_none=True,
+        allow_none=False,
+        required=True,
         data_key="productType",
     )
     name = LocalizedStringField(allow_none=True)
@@ -468,7 +469,8 @@ class ProductProjectionSchema(BaseResourceSchema):
     master_variant = marshmallow.fields.Nested(
         nested="commercetools.schemas._product.ProductVariantSchema",
         unknown=marshmallow.EXCLUDE,
-        allow_none=True,
+        allow_none=False,
+        required=True,
         data_key="masterVariant",
     )
     variants = marshmallow.fields.Nested(

--- a/src/commercetools/testing/product_projections.py
+++ b/src/commercetools/testing/product_projections.py
@@ -1,5 +1,5 @@
 import typing
-
+import dateutil.parser
 from commercetools import schemas, types
 from commercetools.services.product_projections import ProductProjectionsQuerySchema
 from commercetools.testing import utils
@@ -104,23 +104,23 @@ class ProductProjectionsBackend(ServiceBackend):
             "id": product["id"],
             "key": product["key"],
             "version": product["version"],
-            "createdAt": product["createdAt"],
-            "lastModifiedAt": product["lastModifiedAt"],
-            "productType": product["productType"],
+            "created_at": dateutil.parser.parse(product["createdAt"]),
+            "last_modified_at": dateutil.parser.parse(product["lastModifiedAt"]),
+            "product_type": product["productType"],
             "name": data["name"],
             "description": data["description"],
             "slug": data["slug"],
             "categories": data["categories"],
-            "categoryOrderHints": data["categoryOrderHints"],
-            "metaTitle": data["metaTitle"],
-            "metaDescription": data["metaDescription"],
-            "metaKeywords": data["metaKeywords"],
-            "searchKeywords": data["searchKeywords"],
-            "hasStagedChanges": product["masterData"]["hasStagedChanges"],
+            "category_order_hints": data["categoryOrderHints"],
+            "meta_title": data["metaTitle"],
+            "meta_description": data["metaDescription"],
+            "meta_keywords": data["metaKeywords"],
+            "search_keywords": data["searchKeywords"],
+            "has_staged_changes": product["masterData"]["hasStagedChanges"],
             "published": product["masterData"]["published"],
-            "masterVariant": data["masterVariant"],
+            "master_variant": data["masterVariant"],
             "variants": data["variants"],
-            "taxCategory": product["taxCategory"],
+            "tax_category": product["taxCategory"],
             "state": product["state"],
-            "reviewRatingStatistics": product["reviewRatingStatistics"],
+            "review_rating_statistics": product["reviewRatingStatistics"],
         }

--- a/src/commercetools/testing/products.py
+++ b/src/commercetools/testing/products.py
@@ -54,22 +54,30 @@ class ProductsModel(BaseModel):
         self, draft: types.ProductVariantDraft
     ) -> types.ProductVariant:
 
-        assets: typing.Optional[typing.List[types.Asset]] = None
-        if draft.assets:
+        assets: typing.Optional[typing.List[types.Asset]] = []
+        if draft.assets is not None:
             assets = self._create_assets_from_draft(draft.assets)
 
-        prices: typing.Optional[typing.List[types.Price]] = None
-        if draft.prices:
+        prices: typing.Optional[typing.List[types.Price]] = []
+        if draft.prices is not None:
             prices = self._create_prices_from_draft(draft.prices)
+
+        attributes: typing.Optional[typing.List[types.Attribute]] = []
+        if draft.attributes is not None:
+            attributes = draft.attributes
+
+        images: typing.Optional[typing.List[types.Image]] = []
+        if draft.images is not None:
+            images = draft.images
 
         return types.ProductVariant(
             id=1,
             sku=draft.sku,
             key=draft.key,
             prices=prices,
-            attributes=draft.attributes,
+            attributes=attributes,
             price=None,
-            images=draft.images,
+            images=images,
             assets=assets,
             availability=None,
             is_matching_variant=None,


### PR DESCRIPTION
This PR fixes a few items in the `ProductProjection` type handling:

1. `productType` and `masterVariant` are now required fields and `None` is not allowed as a value for these fields
2. empty dictionaries are returned by default for `masterVariant` attributes: `assets`, `images`, `prices`, and `attributes`
3. keys in `ProductProjection` dictionary are converted to snake_case as is expected by the type schema

(1.) According to commercetools [docs](https://docs.commercetools.com/http-api-projects-productProjections), `productType` and `masterVariant` are required fields on Product/ProductProjection objects. Our tests were failing when these expected fields were not present on responses from the mock SDK.

(2.) Regarding the `masterVariant` attribute, the commercetools backend does not support `None` type for lists, but instead returns an empty dictionary `[]`. This behavior was updated in the mock SDK as well. This was found when our tests threw an error when trying to iterate on a `None` type when it expected an emtpy list.

(3.) We found that the schema to de/serialize a `ProductProjection` object in the SDK expected snake_case, but the keys were being saved in camelCase in the creation of `ProuductProjection` dictionary objects. 